### PR TITLE
자판기 앱 3단계 - 앱 생명주기와 객체 저장

### DIFF
--- a/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
+++ b/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		A3040F4421DCC24700B9A831 /* BeverageSubCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3040F4321DCC24700B9A831 /* BeverageSubCategory.swift */; };
+		A3040F4621DDA0D400B9A831 /* Money.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3040F4521DDA0D400B9A831 /* Money.swift */; };
 		A3E1B2EA21CFE07A00B35A96 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E1B2E921CFE07A00B35A96 /* AppDelegate.swift */; };
 		A3E1B2EC21CFE07A00B35A96 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E1B2EB21CFE07A00B35A96 /* ViewController.swift */; };
 		A3E1B2EF21CFE07A00B35A96 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A3E1B2ED21CFE07A00B35A96 /* Main.storyboard */; };
@@ -60,6 +61,7 @@
 
 /* Begin PBXFileReference section */
 		A3040F4321DCC24700B9A831 /* BeverageSubCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeverageSubCategory.swift; sourceTree = "<group>"; };
+		A3040F4521DDA0D400B9A831 /* Money.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Money.swift; sourceTree = "<group>"; };
 		A3E1B2E621CFE07900B35A96 /* VendingMachineApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = VendingMachineApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A3E1B2E921CFE07A00B35A96 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A3E1B2EB21CFE07A00B35A96 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -179,6 +181,7 @@
 		A3E1B33521D06F1F00B35A96 /* VendingMachine */ = {
 			isa = PBXGroup;
 			children = (
+				A3040F4521DDA0D400B9A831 /* Money.swift */,
 				A3E1B33621D06F1F00B35A96 /* Pack.swift */,
 				A3E1B33721D06F1F00B35A96 /* Inventory.swift */,
 				A3E1B33821D06F1F00B35A96 /* VendingMachine.swift */,
@@ -397,6 +400,7 @@
 				A3040F4421DCC24700B9A831 /* BeverageSubCategory.swift in Sources */,
 				A3E1B35E21D0712C00B35A96 /* BeveragePackage.swift in Sources */,
 				A3E1B33A21D06F2000B35A96 /* Pack.swift in Sources */,
+				A3040F4621DDA0D400B9A831 /* Money.swift in Sources */,
 				A3E1B35821D0712C00B35A96 /* SoftDrink.swift in Sources */,
 				A3E1B2EA21CFE07A00B35A96 /* AppDelegate.swift in Sources */,
 				A3E1B34121D06F3900B35A96 /* Date.swift in Sources */,

--- a/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
+++ b/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		A3040F4421DCC24700B9A831 /* BeverageSubCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3040F4321DCC24700B9A831 /* BeverageSubCategory.swift */; };
 		A3040F4621DDA0D400B9A831 /* Money.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3040F4521DDA0D400B9A831 /* Money.swift */; };
+		A3040F4821E448DB00B9A831 /* VendingMachineArchiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3040F4721E448DB00B9A831 /* VendingMachineArchiver.swift */; };
 		A3E1B2EA21CFE07A00B35A96 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E1B2E921CFE07A00B35A96 /* AppDelegate.swift */; };
 		A3E1B2EC21CFE07A00B35A96 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E1B2EB21CFE07A00B35A96 /* ViewController.swift */; };
 		A3E1B2EF21CFE07A00B35A96 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A3E1B2ED21CFE07A00B35A96 /* Main.storyboard */; };
@@ -62,6 +63,7 @@
 /* Begin PBXFileReference section */
 		A3040F4321DCC24700B9A831 /* BeverageSubCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeverageSubCategory.swift; sourceTree = "<group>"; };
 		A3040F4521DDA0D400B9A831 /* Money.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Money.swift; sourceTree = "<group>"; };
+		A3040F4721E448DB00B9A831 /* VendingMachineArchiver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VendingMachineArchiver.swift; sourceTree = "<group>"; };
 		A3E1B2E621CFE07900B35A96 /* VendingMachineApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = VendingMachineApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A3E1B2E921CFE07A00B35A96 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A3E1B2EB21CFE07A00B35A96 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -151,6 +153,7 @@
 			children = (
 				A3E1B33521D06F1F00B35A96 /* VendingMachine */,
 				A3E1B2E921CFE07A00B35A96 /* AppDelegate.swift */,
+				A3040F4721E448DB00B9A831 /* VendingMachineArchiver.swift */,
 				A3E1B2EB21CFE07A00B35A96 /* ViewController.swift */,
 				A3E1B2ED21CFE07A00B35A96 /* Main.storyboard */,
 				A3E1B2F021CFE07C00B35A96 /* Assets.xcassets */,
@@ -394,6 +397,7 @@
 				A3E1B35321D0712C00B35A96 /* Beverage.swift in Sources */,
 				A3E1B35A21D0712C00B35A96 /* BeverageCategory.swift in Sources */,
 				A3E1B35D21D0712C00B35A96 /* Coffee.swift in Sources */,
+				A3040F4821E448DB00B9A831 /* VendingMachineArchiver.swift in Sources */,
 				A3E1B35521D0712C00B35A96 /* Milk.swift in Sources */,
 				A3E1B35B21D0712C00B35A96 /* Georgia.swift in Sources */,
 				A3E1B33B21D06F2000B35A96 /* Inventory.swift in Sources */,

--- a/VendingMachineApp/VendingMachineApp/AppDelegate.swift
+++ b/VendingMachineApp/VendingMachineApp/AppDelegate.swift
@@ -60,7 +60,7 @@ struct VendingMachineArchiver {
     static func load() throws -> VendingMachine {
         guard let data = UserDefaults.standard.data(forKey: "vendingMachine") else { throw ArchivingError.noData }
         guard let vendingMachine = try NSKeyedUnarchiver
-            .unarchivedObject(ofClass: VendingMachine.self, from: data) else { throw ArchivingError.notLoaded }
+            .unarchiveTopLevelObjectWithData(data) as? VendingMachine else { throw ArchivingError.notLoaded }
         return vendingMachine
     }
 

--- a/VendingMachineApp/VendingMachineApp/AppDelegate.swift
+++ b/VendingMachineApp/VendingMachineApp/AppDelegate.swift
@@ -17,7 +17,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         do {
             try vendingMachine = VendingMachineArchiver.load()
         } catch {
-            vendingMachine = VendingMachineArchiver.setDefaultVendingMachine()
+            vendingMachine = VendingMachineArchiver.setDefault()
         }
         return true
     }
@@ -38,36 +38,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func applicationWillTerminate(_ application: UIApplication) {
         VendingMachineArchiver.archive(vendingMachine: vendingMachine)
-    }
-
-}
-
-struct VendingMachineArchiver {
-
-    enum ArchivingError: Error {
-        case noData
-        case notLoaded
-    }
-
-    static func archive(vendingMachine: VendingMachine?) {
-        guard let vendingMachine = vendingMachine else { return }
-        let vendingMachineEncoded = try? NSKeyedArchiver.archivedData(
-            withRootObject: vendingMachine,
-            requiringSecureCoding: false)
-        UserDefaults.standard.set(vendingMachineEncoded, forKey:"vendingMachine")
-    }
-
-    static func load() throws -> VendingMachine {
-        guard let data = UserDefaults.standard.data(forKey: "vendingMachine") else { throw ArchivingError.noData }
-        guard let vendingMachine = try NSKeyedUnarchiver
-            .unarchiveTopLevelObjectWithData(data) as? VendingMachine else { throw ArchivingError.notLoaded }
-        return vendingMachine
-    }
-
-    static func setDefaultVendingMachine() -> VendingMachine {
-        let money = Money()
-        let inventory = Inventory(list: [ObjectIdentifier: Pack]())
-        return VendingMachine.init(initialBalance: money, initialInventory: inventory)
     }
 
 }

--- a/VendingMachineApp/VendingMachineApp/AppDelegate.swift
+++ b/VendingMachineApp/VendingMachineApp/AppDelegate.swift
@@ -10,7 +10,7 @@ import UIKit
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
+    var vendingMachine: VendingMachine?
     var window: UIWindow?
 
 

--- a/VendingMachineApp/VendingMachineApp/AppDelegate.swift
+++ b/VendingMachineApp/VendingMachineApp/AppDelegate.swift
@@ -13,15 +13,25 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var vendingMachine: VendingMachine?
     var window: UIWindow?
 
+    private func loadVendingMachine() {
+        guard let data = UserDefaults.standard.object(forKey: "vendingMachine") as? Data else { return }
+        let decoder = PropertyListDecoder()
+        vendingMachine = try? decoder.decode(VendingMachine.self, from: data)
+    }
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
+        loadVendingMachine()
         return true
     }
 
+    private func archiveVendingMachine() {
+        let encoder = PropertyListEncoder()
+        let vendingMachineEncoded = try? encoder.encode(vendingMachine)
+        UserDefaults.standard.set(vendingMachineEncoded, forKey:"vendingMachine")
+    }
+
     func applicationWillResignActive(_ application: UIApplication) {
-        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-        // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
+        archiveVendingMachine()
     }
 
     func applicationDidEnterBackground(_ application: UIApplication) {

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/Beverage.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/Beverage.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-class Beverage: NSObject, Codable {
+class Beverage: NSObject {
     private let brand: String
     private let name: String
     private let volume: Int
@@ -52,12 +52,51 @@ class Beverage: NSObject, Codable {
         return balance - price
     }
 
-}
-
-extension Beverage {
-
     func showPurchase(with show: (String, Int) -> Void) {
         show(name, price)
+    }
+
+    /* MARK: NSSecrueCoding */
+    required init?(coder aDecoder: NSCoder) {
+        guard let brand = aDecoder
+            .decodeObject(of: NSString.self, forKey: Keys.brand.rawValue) as String? else { return nil }
+        guard let name = aDecoder
+            .decodeObject(of: NSString.self, forKey: Keys.name.rawValue) as String? else { return nil }
+        guard let volume = aDecoder
+            .decodeObject(of: NSNumber.self, forKey: Keys.volume.rawValue) else { return nil }
+        guard let price = aDecoder
+            .decodeObject(of: NSNumber.self , forKey: Keys.price.rawValue) else { return nil }
+        guard let dateOfManufacture = aDecoder
+            .decodeObject(of: NSDate.self, forKey: Keys.dateOfManufacture.rawValue) as Date? else { return nil }
+        self.brand = brand
+        self.name = name
+        self.volume = volume.intValue
+        self.price = price.intValue
+        self.dateOfManufacture = dateOfManufacture
+    }
+
+}
+
+extension Beverage: NSSecureCoding {
+
+    enum Keys: String {
+        case brand = "brand"
+        case name = "name"
+        case volume = "volume"
+        case price = "price"
+        case dateOfManufacture = "dateOfManufacture"
+    }
+
+    static var supportsSecureCoding: Bool {
+        return true
+    }
+
+    func encode(with aCoder: NSCoder) {
+        aCoder.encode(brand as NSString, forKey: Keys.brand.rawValue)
+        aCoder.encode(name as NSString, forKey: Keys.name.rawValue)
+        aCoder.encode(NSNumber(value: volume), forKey: Keys.volume.rawValue)
+        aCoder.encode(NSNumber(value: price), forKey: Keys.price.rawValue)
+        aCoder.encode(dateOfManufacture as NSDate, forKey: Keys.dateOfManufacture.rawValue)
     }
 
 }

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/Beverage.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/Beverage.swift
@@ -59,20 +59,20 @@ class Beverage: NSObject {
     /* MARK: NSSecrueCoding */
     required init?(coder aDecoder: NSCoder) {
         guard let brand = aDecoder
-            .decodeObject(of: NSString.self, forKey: Keys.brand.rawValue) as String? else { return nil }
+            .decodeObject(of: NSString.self, forKey: Keys.brand.rawValue) else { return nil }
         guard let name = aDecoder
-            .decodeObject(of: NSString.self, forKey: Keys.name.rawValue) as String? else { return nil }
+            .decodeObject(of: NSString.self, forKey: Keys.name.rawValue) else { return nil }
         guard let volume = aDecoder
             .decodeObject(of: NSNumber.self, forKey: Keys.volume.rawValue) else { return nil }
         guard let price = aDecoder
             .decodeObject(of: NSNumber.self , forKey: Keys.price.rawValue) else { return nil }
         guard let dateOfManufacture = aDecoder
-            .decodeObject(of: NSDate.self, forKey: Keys.dateOfManufacture.rawValue) as Date? else { return nil }
-        self.brand = brand
-        self.name = name
+            .decodeObject(of: NSDate.self, forKey: Keys.dateOfManufacture.rawValue) else { return nil }
+        self.brand = brand as String
+        self.name = name as String
         self.volume = volume.intValue
         self.price = price.intValue
-        self.dateOfManufacture = dateOfManufacture
+        self.dateOfManufacture = dateOfManufacture as Date
     }
 
 }

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/Beverage.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/Beverage.swift
@@ -57,17 +57,25 @@ class Beverage: NSObject {
     }
 
     /* MARK: NSSecrueCoding */
+    private struct Default {
+        static let brand: NSString = "노브랜드"
+        static let name: NSString = "물"
+        static let volume: NSNumber = 500
+        static let price: NSNumber = 800
+        static let dateOfManufacture: NSDate = Date.subtractingDaysFromNow(by: 30) as NSDate
+    }
+
     required init?(coder aDecoder: NSCoder) {
-        guard let brand = aDecoder
-            .decodeObject(of: NSString.self, forKey: Keys.brand.rawValue) else { return nil }
-        guard let name = aDecoder
-            .decodeObject(of: NSString.self, forKey: Keys.name.rawValue) else { return nil }
-        guard let volume = aDecoder
-            .decodeObject(of: NSNumber.self, forKey: Keys.volume.rawValue) else { return nil }
-        guard let price = aDecoder
-            .decodeObject(of: NSNumber.self , forKey: Keys.price.rawValue) else { return nil }
-        guard let dateOfManufacture = aDecoder
-            .decodeObject(of: NSDate.self, forKey: Keys.dateOfManufacture.rawValue) else { return nil }
+        let brand = aDecoder
+            .decodeObject(of: NSString.self, forKey: Keys.brand.rawValue) ?? Default.brand
+        let name = aDecoder
+            .decodeObject(of: NSString.self, forKey: Keys.name.rawValue) ?? Default.name
+        let volume = aDecoder
+            .decodeObject(of: NSNumber.self, forKey: Keys.volume.rawValue) ?? Default.volume
+        let price = aDecoder
+            .decodeObject(of: NSNumber.self , forKey: Keys.price.rawValue) ?? Default.price
+        let dateOfManufacture = aDecoder
+            .decodeObject(of: NSDate.self, forKey: Keys.dateOfManufacture.rawValue) ?? Default.dateOfManufacture
         self.brand = brand as String
         self.name = name as String
         self.volume = volume.intValue
@@ -79,7 +87,7 @@ class Beverage: NSObject {
 
 extension Beverage: NSSecureCoding {
 
-    enum Keys: String {
+    private enum Keys: String {
         case brand = "brand"
         case name = "name"
         case volume = "volume"

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/Beverage.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/Beverage.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-class Beverage: NSObject {
+class Beverage: NSObject, Codable {
     private let brand: String
     private let name: String
     private let volume: Int

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/BeverageCategory.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/BeverageCategory.swift
@@ -8,8 +8,8 @@
 
 import Foundation
 
-enum BeverageCategory {
-    case milk
+enum BeverageCategory: Int, Codable {
+    case milk = 0
     case softDrink
     case coffee
     case etc

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/BeveragePackage.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/BeveragePackage.swift
@@ -8,8 +8,8 @@
 
 import Foundation
 
-enum BeveragePackage {
-    case paper
+enum BeveragePackage: Int, Codable {
+    case paper = 0
     case plastic
     case can
 }

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/BeverageSubCategory.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/BeverageSubCategory.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-enum BeverageSubCategory: Int, CaseIterable{
+enum BeverageSubCategory: Int, CaseIterable, Codable{
     case chocolateMilk = 0, strawberryMilk
     case sprite, pepsi
     case cantata, georgia

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/Coffee/Coffee.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/Coffee/Coffee.swift
@@ -35,6 +35,16 @@ class Coffee: BeverageGroup {
             ice: true)
     }
 
+    enum CodingKeys: String, CodingKey {
+        case ice
+    }
+
+    required init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        ice = try values.decode(Bool.self, forKey: .ice)
+        try super.init(from: decoder)
+    }
+
     override var group: BeverageCategory {
         return .coffee
     }

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/Coffee/Coffee.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/Coffee/Coffee.swift
@@ -44,7 +44,7 @@ class Coffee: BeverageGroup {
     }
 
     /* MARK: NSSecureCoding */
-    enum Keys: String {
+    private enum Keys: String {
         case ice = "ice"
     }
 

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/Coffee/Coffee.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/Coffee/Coffee.swift
@@ -35,22 +35,27 @@ class Coffee: BeverageGroup {
             ice: true)
     }
 
-    enum CodingKeys: String, CodingKey {
-        case ice
-    }
-
-    required init(from decoder: Decoder) throws {
-        let values = try decoder.container(keyedBy: CodingKeys.self)
-        ice = try values.decode(Bool.self, forKey: .ice)
-        try super.init(from: decoder)
-    }
-
     override var group: BeverageCategory {
         return .coffee
     }
 
     func isHot() -> Bool {
         return !ice
+    }
+
+    /* MARK: NSSecureCoding */
+    enum Keys: String {
+        case ice = "ice"
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        ice = aDecoder.decodeBool(forKey: Keys.ice.rawValue)
+        super.init(coder: aDecoder)
+    }
+
+    override func encode(with aCoder: NSCoder) {
+        super.encode(with: aCoder)
+        aCoder.encode(ice, forKey: Keys.ice.rawValue)
     }
 
 }

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/Milk/ChocolateMilk.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/Milk/ChocolateMilk.swift
@@ -28,6 +28,7 @@ class ChocolateMilk: Milk {
                      volume: Int,
                      price: Int,
                      dateOfManufacture: Date,
+                     useByDate: Double,
                      package: BeveragePackage) {
         self.init(brand: brand,
                   name: name,
@@ -35,6 +36,7 @@ class ChocolateMilk: Milk {
                   price: price,
                   dateOfManufacture: dateOfManufacture,
                   flavor: "초코",
+                  useByDate: useByDate,
                   package: package)
     }
 

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/Milk/Milk.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/Milk/Milk.swift
@@ -83,11 +83,11 @@ class Milk: BeverageGroup {
         guard let useByDate = aDecoder
             .decodeObject(of: NSNumber.self, forKey: Keys.useByDate.rawValue) else { return nil }
         guard let expirationDate = aDecoder
-            .decodeObject(of: NSDate.self, forKey: Keys.expirationDate.rawValue) as Date? else { return nil }
+            .decodeObject(of: NSDate.self, forKey: Keys.expirationDate.rawValue) else { return nil }
         guard let package = BeveragePackage(rawValue: packageNumber.intValue) else { return nil }
         self.package = package
         self.useByDate = useByDate.doubleValue
-        self.expirationDate = expirationDate
+        self.expirationDate = expirationDate as Date
         super.init(coder: aDecoder)
     }
 

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/Milk/Milk.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/Milk/Milk.swift
@@ -96,7 +96,7 @@ class Milk: BeverageGroup {
         aCoder.encode(flavor as NSString?, forKey: Keys.flavor.rawValue)
         aCoder.encode(NSNumber(value: package.rawValue), forKey: Keys.package.rawValue)
         aCoder.encode(NSNumber(value: useByDate), forKey: Keys.useByDate.rawValue)
-        aCoder.encode(expirationDate as NSDate, forKey: Keys.useByDate.rawValue)
+        aCoder.encode(expirationDate as NSDate, forKey: Keys.expirationDate.rawValue)
     }
 
 }

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/Milk/Milk.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/Milk/Milk.swift
@@ -11,7 +11,7 @@ import Foundation
 class Milk: BeverageGroup {
     private let flavor: String?
     private let package: BeveragePackage
-    private var useByDate: Double = 10
+    private let useByDate: Double
     private let expirationDate: Date
 
     init(brand: String,
@@ -20,9 +20,11 @@ class Milk: BeverageGroup {
          price: Int,
          dateOfManufacture: Date,
          flavor: String? = nil,
+         useByDate: Double,
          package: BeveragePackage) {
         self.flavor = flavor
         self.package = package
+        self.useByDate = useByDate
         self.expirationDate = dateOfManufacture.addingDayInterval(useByDate)
         super.init(brand: brand,
                    name: name,
@@ -43,6 +45,7 @@ class Milk: BeverageGroup {
                   price: price,
                   dateOfManufacture: dateOfManufacture,
                   flavor: flavor,
+                  useByDate: 10,
                   package: BeveragePackage.paper)
     }
 
@@ -53,6 +56,7 @@ class Milk: BeverageGroup {
                   price: 1000,
                   dateOfManufacture: Date.subtractingDaysFromNow(by: 5),
                   flavor: nil,
+                  useByDate: 10,
                   package: BeveragePackage.paper)
     }
 

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/Milk/Milk.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/Milk/Milk.swift
@@ -56,22 +56,6 @@ class Milk: BeverageGroup {
                   package: BeveragePackage.paper)
     }
 
-    enum CodingKeys: String, CodingKey {
-        case flavor
-        case package
-        case useByDate
-        case expirationDate
-    }
-    
-    required init(from decoder: Decoder) throws {
-        let values = try decoder.container(keyedBy: CodingKeys.self)
-        flavor = try values.decode(String.self, forKey: .flavor)
-        package = try values.decode(BeveragePackage.self, forKey: .package)
-        useByDate = try values.decode(Double.self, forKey: .useByDate)
-        expirationDate = try values.decode(Date.self, forKey: .expirationDate)
-        try super.init(from: decoder)
-    }
-
     override var group: BeverageCategory {
         return .milk
     }
@@ -82,6 +66,37 @@ class Milk: BeverageGroup {
 
     func validate(when date:Date) -> Bool {
         return date < expirationDate
+    }
+
+    /* MARK: NSSecureConding*/
+    enum Keys: String {
+        case flavor = "flavor"
+        case package = "package"
+        case useByDate = "useByDate"
+        case expirationDate = "expirationDate"
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        flavor = aDecoder.decodeObject(of: NSString.self, forKey: Keys.flavor.rawValue) as String?
+        guard let packageNumber = aDecoder
+            .decodeObject(of: NSNumber.self, forKey: Keys.package.rawValue) else { return nil }
+        guard let useByDate = aDecoder
+            .decodeObject(of: NSNumber.self, forKey: Keys.useByDate.rawValue) else { return nil }
+        guard let expirationDate = aDecoder
+            .decodeObject(of: NSDate.self, forKey: Keys.expirationDate.rawValue) as Date? else { return nil }
+        guard let package = BeveragePackage(rawValue: packageNumber.intValue) else { return nil }
+        self.package = package
+        self.useByDate = useByDate.doubleValue
+        self.expirationDate = expirationDate
+        super.init(coder: aDecoder)
+    }
+
+    override func encode(with aCoder: NSCoder) {
+        super.encode(with: aCoder)
+        aCoder.encode(flavor as NSString?, forKey: Keys.flavor.rawValue)
+        aCoder.encode(NSNumber(value: package.rawValue), forKey: Keys.package.rawValue)
+        aCoder.encode(NSNumber(value: useByDate), forKey: Keys.useByDate.rawValue)
+        aCoder.encode(expirationDate as NSDate, forKey: Keys.useByDate.rawValue)
     }
 
 }

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/Milk/Milk.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/Milk/Milk.swift
@@ -11,7 +11,7 @@ import Foundation
 class Milk: BeverageGroup {
     private let flavor: String?
     private let package: BeveragePackage
-    private let useByDate: Double = 10
+    private var useByDate: Double = 10
     private let expirationDate: Date
 
     init(brand: String,
@@ -54,6 +54,22 @@ class Milk: BeverageGroup {
                   dateOfManufacture: Date.subtractingDaysFromNow(by: 5),
                   flavor: nil,
                   package: BeveragePackage.paper)
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case flavor
+        case package
+        case useByDate
+        case expirationDate
+    }
+    
+    required init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        flavor = try values.decode(String.self, forKey: .flavor)
+        package = try values.decode(BeveragePackage.self, forKey: .package)
+        useByDate = try values.decode(Double.self, forKey: .useByDate)
+        expirationDate = try values.decode(Date.self, forKey: .expirationDate)
+        try super.init(from: decoder)
     }
 
     override var group: BeverageCategory {

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/Milk/Milk.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/Milk/Milk.swift
@@ -73,7 +73,15 @@ class Milk: BeverageGroup {
     }
 
     /* MARK: NSSecureConding*/
-    enum Keys: String {
+    private struct Default {
+        static let flavor: NSString? = nil
+        static let package: BeveragePackage = .paper
+        static let packageNumber: NSNumber = package.rawValue as NSNumber
+        static let useByDate: NSNumber = 10
+        static let expirationDate: NSDate = Date.subtractingDaysFromNow(by: 5) as NSDate
+    }
+
+    private enum Keys: String {
         case flavor = "flavor"
         case package = "package"
         case useByDate = "useByDate"
@@ -81,14 +89,16 @@ class Milk: BeverageGroup {
     }
 
     required init?(coder aDecoder: NSCoder) {
-        flavor = aDecoder.decodeObject(of: NSString.self, forKey: Keys.flavor.rawValue) as String?
-        guard let packageNumber = aDecoder
-            .decodeObject(of: NSNumber.self, forKey: Keys.package.rawValue) else { return nil }
-        guard let useByDate = aDecoder
-            .decodeObject(of: NSNumber.self, forKey: Keys.useByDate.rawValue) else { return nil }
-        guard let expirationDate = aDecoder
-            .decodeObject(of: NSDate.self, forKey: Keys.expirationDate.rawValue) else { return nil }
-        guard let package = BeveragePackage(rawValue: packageNumber.intValue) else { return nil }
+        let flavor = aDecoder
+            .decodeObject(of: NSString.self, forKey: Keys.flavor.rawValue) ?? Default.flavor
+        let packageNumber = aDecoder
+            .decodeObject(of: NSNumber.self, forKey: Keys.package.rawValue) ?? Default.packageNumber
+        let package = BeveragePackage(rawValue: packageNumber.intValue) ?? Default.package
+        let useByDate = aDecoder
+            .decodeObject(of: NSNumber.self, forKey: Keys.useByDate.rawValue) ?? Default.useByDate
+        let expirationDate = aDecoder
+            .decodeObject(of: NSDate.self, forKey: Keys.expirationDate.rawValue) ?? Default.expirationDate
+        self.flavor = flavor as String?
         self.package = package
         self.useByDate = useByDate.doubleValue
         self.expirationDate = expirationDate as Date

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/Milk/StrawberryMilk.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/Milk/StrawberryMilk.swift
@@ -28,6 +28,7 @@ class StrawberryMilk: Milk {
                      volume: Int,
                      price: Int,
                      dateOfManufacture: Date,
+                     useByDate: Double,
                      package: BeveragePackage) {
         self.init(brand: brand,
                   name: name,
@@ -35,6 +36,7 @@ class StrawberryMilk: Milk {
                   price: price,
                   dateOfManufacture: dateOfManufacture,
                   flavor: "딸기",
+                  useByDate: useByDate,
                   package: package)
     }
 

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/SoftDrink/SoftDrink.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/SoftDrink/SoftDrink.swift
@@ -40,14 +40,19 @@ class SoftDrink: BeverageGroup {
     }
 
     /* MARK: NSSecureCoding*/
-    enum Keys: String {
+    private struct Default {
+        static let package: BeveragePackage = .plastic
+        static let packageNumber: NSNumber = package.rawValue as NSNumber
+    }
+
+    private enum Keys: String {
         case package = "package"
     }
 
     required init?(coder aDecoder: NSCoder) {
-        guard let packageNumber = aDecoder
-            .decodeObject(of: NSNumber.self, forKey: Keys.package.rawValue) else { return nil }
-        guard let package = BeveragePackage(rawValue: packageNumber.intValue) else { return nil }
+        let packageNumber = aDecoder
+            .decodeObject(of: NSNumber.self, forKey: Keys.package.rawValue) ?? Default.packageNumber
+        let package = BeveragePackage(rawValue: packageNumber.intValue) ?? Default.package
         self.package = package
         super.init(coder: aDecoder)
     }

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/SoftDrink/SoftDrink.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/SoftDrink/SoftDrink.swift
@@ -35,18 +35,26 @@ class SoftDrink: BeverageGroup {
             package: .plastic)
     }
 
-    enum CodingKeys: String, CodingKey {
-        case package
-    }
-    
-    required init(from decoder: Decoder) throws {
-        let values = try decoder.container(keyedBy: CodingKeys.self)
-        package = try values.decode(BeveragePackage.self, forKey: .package)
-        try super.init(from: decoder)
-    }
-
     override var group: BeverageCategory {
         return .softDrink
+    }
+
+    /* MARK: NSSecureCoding*/
+    enum Keys: String {
+        case package = "package"
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        guard let packageNumber = aDecoder
+            .decodeObject(of: NSNumber.self, forKey: Keys.package.rawValue) else { return nil }
+        guard let package = BeveragePackage(rawValue: packageNumber) else { return nil }
+        self.package = package
+        super.init(coder: aDecoder)
+    }
+
+    override func encode(with aCoder: NSCoder) {
+        super.encode(with: aCoder)
+        aCoder.encode(NSNumber(value: package.rawValue), forKey: "package")
     }
 
 }

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/SoftDrink/SoftDrink.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/SoftDrink/SoftDrink.swift
@@ -47,7 +47,7 @@ class SoftDrink: BeverageGroup {
     required init?(coder aDecoder: NSCoder) {
         guard let packageNumber = aDecoder
             .decodeObject(of: NSNumber.self, forKey: Keys.package.rawValue) else { return nil }
-        guard let package = BeveragePackage(rawValue: packageNumber) else { return nil }
+        guard let package = BeveragePackage(rawValue: packageNumber.intValue) else { return nil }
         self.package = package
         super.init(coder: aDecoder)
     }

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/SoftDrink/SoftDrink.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/Beverage/SoftDrink/SoftDrink.swift
@@ -35,6 +35,16 @@ class SoftDrink: BeverageGroup {
             package: .plastic)
     }
 
+    enum CodingKeys: String, CodingKey {
+        case package
+    }
+    
+    required init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        package = try values.decode(BeveragePackage.self, forKey: .package)
+        try super.init(from: decoder)
+    }
+
     override var group: BeverageCategory {
         return .softDrink
     }

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/History.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/History.swift
@@ -38,9 +38,13 @@ class History: NSObject {
     }
 
     /* MARK: NSSecureCoding */
+    private struct Default {
+        static let purchases = [Beverage]()
+    }
+
     required init?(coder aDecoder: NSCoder) {
-        guard let purchases = aDecoder
-            .decodeObject(forKey: Keys.purchases.rawValue) as? [Beverage] else { return nil }
+        let purchases = aDecoder
+            .decodeObject(forKey: Keys.purchases.rawValue) as? [Beverage] ?? Default.purchases
         self.purchases = purchases
     }
 
@@ -48,7 +52,7 @@ class History: NSObject {
 
 extension History: NSSecureCoding {
 
-    enum Keys: String {
+    private enum Keys: String {
         case purchases = "purchases"
     }
 

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/History.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/History.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-class History {
+class History: Codable {
     private var purchases: [Beverage]
 
     init(purchases: [Beverage]) {

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/History.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/History.swift
@@ -8,14 +8,14 @@
 
 import Foundation
 
-class History: Codable {
+class History: NSObject {
     private var purchases: [Beverage]
 
     init(purchases: [Beverage]) {
         self.purchases = purchases
     }
 
-    convenience init() {
+    convenience override init() {
         self.init(purchases: [])
     }
 
@@ -33,12 +33,31 @@ class History: Codable {
         }
     }
 
-}
-
-extension History: Equatable {
-
     static func == (lhs: History, rhs: History) -> Bool {
         return lhs.purchases == rhs.purchases
+    }
+
+    /* MARK: NSSecureCoding */
+    required init?(coder aDecoder: NSCoder) {
+        guard let purchases = aDecoder
+            .decodeObject(forKey: Keys.purchases.rawValue) as? [Beverage] else { return nil }
+        self.purchases = purchases
+    }
+
+}
+
+extension History: NSSecureCoding {
+
+    enum Keys: String {
+        case purchases = "purchases"
+    }
+
+    static var supportsSecureCoding: Bool {
+        return true
+    }
+
+    func encode(with aCoder: NSCoder) {
+        aCoder.encode(purchases, forKey: Keys.purchases.rawValue)
     }
 
 }

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/Inventory.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/Inventory.swift
@@ -80,8 +80,12 @@ class Inventory: NSObject {
     }
 
     /* MARK: NSSecureCoding*/
+    private struct Default {
+        static let packs = [Pack]()
+    }
+
     required init?(coder aDecoder: NSCoder) {
-        guard let packs = aDecoder.decodeObject(forKey: Keys.packs.rawValue) as? [Pack] else { return nil }
+        let packs = aDecoder.decodeObject(forKey: Keys.packs.rawValue) as? [Pack] ?? Default.packs
         var list = [ObjectIdentifier: Pack]()
         for pack in packs {
             guard let identifier = pack.identifier else { continue }
@@ -94,7 +98,7 @@ class Inventory: NSObject {
 
 extension Inventory: NSSecureCoding {
 
-    enum Keys: String {
+    private enum Keys: String {
         case packs = "packs"
     }
 

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/Inventory.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/Inventory.swift
@@ -81,7 +81,7 @@ class Inventory: NSObject {
 
     /* MARK: NSSecureCoding*/
     required init?(coder aDecoder: NSCoder) {
-        guard let packs = aDecoder.decodeObject(of: [Pack.self], forKey: Keys.packs.rawValue) as? [Pack] else { return nil }
+        guard let packs = aDecoder.decodeObject(forKey: Keys.packs.rawValue) as? [Pack] else { return nil }
         var list = [ObjectIdentifier: Pack]()
         for pack in packs {
             guard let identifier = pack.identifier else { continue }

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/Inventory.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/Inventory.swift
@@ -81,7 +81,7 @@ class Inventory: NSObject {
 
     /* MARK: NSSecureCoding*/
     required init?(coder aDecoder: NSCoder) {
-        guard let packs = aDecoder.decodeObject(forKey: Keys.packs.rawValue) as? [Pack] else { return nil }
+        guard let packs = aDecoder.decodeObject(of: [Pack.self], forKey: Keys.packs.rawValue) as? [Pack] else { return nil }
         var list = [ObjectIdentifier: Pack]()
         for pack in packs {
             guard let identifier = pack.identifier else { continue }

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/Inventory.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/Inventory.swift
@@ -8,35 +8,11 @@
 
 import Foundation
 
-class Inventory: Codable {
+class Inventory: NSObject {
     private var list: [ObjectIdentifier: Pack]
 
     init(list: [ObjectIdentifier: Pack]) {
         self.list = list
-    }
-
-    enum CodingKeys: String, CodingKey {
-        case packs
-    }
-
-    required init(from decoder: Decoder) throws {
-        let values = try decoder.container(keyedBy: CodingKeys.self)
-        let packs = try values.decode([Pack].self, forKey: .packs) as [Pack]
-        var listDecoded = [ObjectIdentifier: Pack]()
-        for pack in packs {
-            guard let identifier = pack.identifier else { continue }
-            listDecoded[identifier] = pack
-        }
-        list = listDecoded
-    }
-
-    func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(packs, forKey: .packs)
-    }
-
-    var packs: [Pack] {
-        return list.values.map { $0 }
     }
 
     func hasNoBeverage(of beverage: Beverage.Type) -> Bool {
@@ -101,6 +77,34 @@ class Inventory: Codable {
             guard item.value.isEmpty() else { return false }
         }
         return true
+    }
+
+    /* MARK: NSSecureCoding*/
+    required init?(coder aDecoder: NSCoder) {
+        guard let packs = aDecoder.decodeObject(forKey: Keys.packs.rawValue) as? [Pack] else { return nil }
+        var list = [ObjectIdentifier: Pack]()
+        for pack in packs {
+            guard let identifier = pack.identifier else { continue }
+            list[identifier] = pack
+        }
+        self.list = list
+    }
+
+}
+
+extension Inventory: NSSecureCoding {
+
+    enum Keys: String {
+        case packs = "packs"
+    }
+
+    static var supportsSecureCoding: Bool {
+        return true
+    }
+
+    func encode(with aCoder: NSCoder) {
+        let packs = list.values.map { $0 }
+        aCoder.encode(packs, forKey: Keys.packs.rawValue)
     }
 
 }

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/Inventory.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/Inventory.swift
@@ -8,11 +8,35 @@
 
 import Foundation
 
-class Inventory {
+class Inventory: Codable {
     private var list: [ObjectIdentifier: Pack]
 
     init(list: [ObjectIdentifier: Pack]) {
         self.list = list
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case packs
+    }
+
+    required init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        let packs = try values.decode([Pack].self, forKey: .packs) as [Pack]
+        var listDecoded = [ObjectIdentifier: Pack]()
+        for pack in packs {
+            guard let identifier = pack.identifier else { continue }
+            listDecoded[identifier] = pack
+        }
+        list = listDecoded
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(packs, forKey: .packs)
+    }
+
+    var packs: [Pack] {
+        return list.values.map { $0 }
     }
 
     func hasNoBeverage(of beverage: Beverage.Type) -> Bool {

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/Inventory.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/Inventory.swift
@@ -44,8 +44,8 @@ class Inventory {
         return listOfAll
     }
 
-    func getListBuyable(with money: Int) -> [Pack] {
-        return list.values.filter { $0.isBuyable(with: money) }
+    func getListBuyable(with money: Money) -> [Pack] {
+        return list.values.filter { money.isEnoughToBuy(pack: $0) }
     }
 
     func getListOfHotBeverages() -> [Pack] {

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/Money.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/Money.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct Money {
+struct Money: Codable {
     private var balance: Int
 
     enum Unit: Int {

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/Money.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/Money.swift
@@ -1,0 +1,48 @@
+//
+//  Money.swift
+//  VendingMachineApp
+//
+//  Created by 윤지영 on 03/01/2019.
+//  Copyright © 2019 윤지영. All rights reserved.
+//
+
+import Foundation
+
+struct Money {
+    private var balance: Int
+
+    enum Unit: Int {
+        case oneThousand = 1000
+        case fiveThousands = 5000
+    }
+
+    init(initialBalance: Int = 0) {
+        self.balance = initialBalance
+    }
+
+    init(unit: Money.Unit) {
+        self.balance = unit.rawValue
+    }
+
+    func isPositive() -> Bool {
+        return balance > 0
+    }
+
+    static func +(_ lhs: Money, _ rhs: Money) -> Money {
+        let sum = lhs.balance + rhs.balance
+        return Money(initialBalance: sum)
+    }
+
+    mutating func deductedPrice(of beverage: Beverage) {
+        balance = beverage.subtractPrice(from: balance)
+    }
+
+    func show(with show: (Int) -> Void) {
+        show(balance)
+    }
+
+    func isEnoughToBuy(pack: Pack) -> Bool {
+        return pack.isBuyable(with: balance)
+    }
+
+}

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/Money.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/Money.swift
@@ -46,9 +46,13 @@ class Money: NSObject {
     }
 
     /* MARK: NSSecureCoding */
+    private struct Defualt {
+        static let balance: NSNumber = 0
+    }
+
     required init?(coder aDecoder: NSCoder) {
-        guard let balance = aDecoder
-            .decodeObject(of: NSNumber.self, forKey: Keys.balance.rawValue) else { return nil }
+        let balance = aDecoder
+            .decodeObject(of: NSNumber.self, forKey: Keys.balance.rawValue) ?? Defualt.balance
         self.balance = balance.intValue
     }
 
@@ -56,7 +60,7 @@ class Money: NSObject {
 
 extension Money: NSSecureCoding {
 
-    enum Keys: String {
+    private enum Keys: String {
         case balance = "balance"
     }
 

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/Money.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/Money.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct Money: Codable {
+class Money: NSObject {
     private var balance: Int
 
     enum Unit: Int {
@@ -33,7 +33,7 @@ struct Money: Codable {
         return Money(initialBalance: sum)
     }
 
-    mutating func deductedPrice(of beverage: Beverage) {
+    func deductedPrice(of beverage: Beverage) {
         balance = beverage.subtractPrice(from: balance)
     }
 
@@ -43,6 +43,29 @@ struct Money: Codable {
 
     func isEnoughToBuy(pack: Pack) -> Bool {
         return pack.isBuyable(with: balance)
+    }
+
+    /* MARK: NSSecureCoding */
+    required init?(coder aDecoder: NSCoder) {
+        guard let balance = aDecoder
+            .decodeObject(of: NSNumber.self, forKey: Keys.balance.rawValue) else { return nil }
+        self.balance = balance.intValue
+    }
+
+}
+
+extension Money: NSSecureCoding {
+
+    enum Keys: String {
+        case balance = "balance"
+    }
+
+    static var supportsSecureCoding: Bool {
+        return true
+    }
+
+    func encode(with aCoder: NSCoder) {
+        aCoder.encode(NSNumber(value: balance), forKey: Keys.balance.rawValue)
     }
 
 }

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/Pack.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/Pack.swift
@@ -77,11 +77,11 @@ class Pack: NSObject {
     /* MARK: NSSecureCoding */
     required init?(coder aDecoder: NSCoder) {
         guard let beverages = aDecoder
-            .decodeObject(of: [Beverage.self], forKey: Keys.beverages.rawValue) as? [Beverage] else { return nil }
+            .decodeObject(forKey: Keys.beverages.rawValue) as? [Beverage] else { return nil }
         guard let title = aDecoder
-            .decodeObject(of: NSString.self, forKey: Keys.title.rawValue) as String? else { return nil }
+            .decodeObject(of: NSString.self, forKey: Keys.title.rawValue) else { return nil }
         self.beverages = beverages
-        self.title = title
+        self.title = title as String
     }
 
 }

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/Pack.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/Pack.swift
@@ -99,7 +99,7 @@ extension Pack: NSSecureCoding {
 
     func encode(with aCoder: NSCoder) {
         aCoder.encode(beverages, forKey: Keys.beverages.rawValue)
-        aCoder.encode(title as NSString, forKey: Keys.beverages.rawValue)
+        aCoder.encode(title as NSString, forKey: Keys.title.rawValue)
     }
 
 }

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/Pack.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/Pack.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-class Pack: NSObject {
+class Pack: NSObject, Codable {
     private var beverages: [Beverage]
     private(set) var title: String
 
@@ -19,6 +19,11 @@ class Pack: NSObject {
             return
         }
         self.title = ""
+    }
+
+    var identifier: ObjectIdentifier? {
+        guard let one = beverages.first else { return nil }
+        return ObjectIdentifier(type(of: one))
     }
 
     func add(beverage: Beverage) {

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/Pack.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/Pack.swift
@@ -77,7 +77,7 @@ class Pack: NSObject {
     /* MARK: NSSecureCoding */
     required init?(coder aDecoder: NSCoder) {
         guard let beverages = aDecoder
-            .decodeObject(forKey: Keys.beverages.rawValue) as? [Beverage] else { return nil }
+            .decodeObject(of: [Beverage.self], forKey: Keys.beverages.rawValue) as? [Beverage] else { return nil }
         guard let title = aDecoder
             .decodeObject(of: NSString.self, forKey: Keys.title.rawValue) as String? else { return nil }
         self.beverages = beverages

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/Pack.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/Pack.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-class Pack: NSObject, Codable {
+class Pack: NSObject {
     private var beverages: [Beverage]
     private(set) var title: String
 
@@ -72,6 +72,34 @@ class Pack: NSObject, Codable {
             expiredBeverages.append(milk)
         }
         return expiredBeverages
+    }
+
+    /* MARK: NSSecureCoding */
+    required init?(coder aDecoder: NSCoder) {
+        guard let beverages = aDecoder
+            .decodeObject(forKey: Keys.beverages.rawValue) as? [Beverage] else { return nil }
+        guard let title = aDecoder
+            .decodeObject(of: NSString.self, forKey: Keys.title.rawValue) as String? else { return nil }
+        self.beverages = beverages
+        self.title = title
+    }
+
+}
+
+extension Pack: NSSecureCoding {
+
+    enum Keys: String {
+        case beverages = "beverages"
+        case title = "title"
+    }
+
+    static var supportsSecureCoding: Bool {
+        return true
+    }
+
+    func encode(with aCoder: NSCoder) {
+        aCoder.encode(beverages, forKey: Keys.beverages.rawValue)
+        aCoder.encode(title as NSString, forKey: Keys.beverages.rawValue)
     }
 
 }

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/Pack.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/Pack.swift
@@ -75,11 +75,16 @@ class Pack: NSObject {
     }
 
     /* MARK: NSSecureCoding */
+    private struct Default {
+        static let beverages = [Beverage]()
+        static let title: NSString = ""
+    }
+
     required init?(coder aDecoder: NSCoder) {
-        guard let beverages = aDecoder
-            .decodeObject(forKey: Keys.beverages.rawValue) as? [Beverage] else { return nil }
-        guard let title = aDecoder
-            .decodeObject(of: NSString.self, forKey: Keys.title.rawValue) else { return nil }
+        let beverages = aDecoder
+            .decodeObject(forKey: Keys.beverages.rawValue) as? [Beverage] ?? Default.beverages
+        let title = aDecoder
+            .decodeObject(of: NSString.self, forKey: Keys.title.rawValue) ?? Default.title
         self.beverages = beverages
         self.title = title as String
     }
@@ -88,7 +93,7 @@ class Pack: NSObject {
 
 extension Pack: NSSecureCoding {
 
-    enum Keys: String {
+    private enum Keys: String {
         case beverages = "beverages"
         case title = "title"
     }

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/VendingMachine.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/VendingMachine.swift
@@ -34,7 +34,7 @@ protocol PrintableForManager {
     func showHistory(with: (Int, String) -> Void)
 }
 
-struct VendingMachine {
+struct VendingMachine: Codable {
     private var balance: Money
     private var inventory: Inventory
     private var history: History

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/VendingMachine.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/VendingMachine.swift
@@ -60,13 +60,20 @@ class VendingMachine: NSObject {
     }
 
     /* MARK: NSSecureCoding */
+    private struct Default {
+        static let balance = Money()
+        private static let emptyList = [ObjectIdentifier: Pack]()
+        static let inventory = Inventory(list: emptyList)
+        static let history = History()
+    }
+
     required init?(coder aDecoder: NSCoder) {
-        guard let balance = aDecoder
-            .decodeObject(of: Money.self, forKey: Keys.balance.rawValue) else { return nil }
-        guard let inventory = aDecoder
-            .decodeObject(of: Inventory.self, forKey: Keys.inventory.rawValue) else { return nil }
-        guard let history = aDecoder
-            .decodeObject(of: History.self, forKey: Keys.history.rawValue) else { return nil }
+        let balance = aDecoder
+            .decodeObject(of: Money.self, forKey: Keys.balance.rawValue) ?? Default.balance
+        let inventory = aDecoder
+            .decodeObject(of: Inventory.self, forKey: Keys.inventory.rawValue) ?? Default.inventory
+        let history = aDecoder
+            .decodeObject(of: History.self, forKey: Keys.history.rawValue) ?? Default.history
         self.balance = balance
         self.inventory = inventory
         self.history = history

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/VendingMachine.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/VendingMachine.swift
@@ -10,7 +10,7 @@ import Foundation
 
 protocol Consumer {
     func isEmpty() -> Bool
-    mutating func insert(money: Int) -> Bool
+    mutating func insert(money: Money) -> Bool
     func getListBuyable() -> [Pack]
     mutating func buy(beverage: Pack) -> Beverage?
 }
@@ -35,12 +35,12 @@ protocol PrintableForManager {
 }
 
 struct VendingMachine {
-    private var balance: Int
+    private var balance: Money
     private var inventory: Inventory
     private var history: History
 
-    init(beginningBalance: Int = 0, initialInventory: Inventory) {
-        self.balance = beginningBalance
+    init(initialBalance: Money = Money(), initialInventory: Inventory) {
+        self.balance = initialBalance
         self.inventory = initialInventory
         self.history = History()
     }
@@ -67,9 +67,9 @@ extension VendingMachine: Consumer {
         return inventory.isEmpty()
     }
 
-    mutating func insert(money: Int) -> Bool {
-        guard money > 0 else { return false }
-        balance += money
+    mutating func insert(money: Money) -> Bool {
+        guard money.isPositive() else { return false }
+        balance = balance + money
         return true
     }
 
@@ -79,7 +79,7 @@ extension VendingMachine: Consumer {
 
     mutating func buy(beverage pack: Pack) -> Beverage? {
         guard let beverage = inventory.remove(selected: pack) else { return nil }
-        balance = beverage.subtractPrice(from: balance)
+        balance.deductedPrice(of: beverage)
         history.update(purchase: beverage)
         return beverage
     }
@@ -88,8 +88,8 @@ extension VendingMachine: Consumer {
 
 extension VendingMachine: PrintableForConsumer {
 
-    func showBalance(with show: (Int) -> Void) {
-        show(balance)
+    func showBalance(with form: (Int) -> Void) {
+        balance.show(with: form)
     }
 
     func showListOfBuyable(with show: (Bool, Int, String) -> Void) {

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/VendingMachine.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/VendingMachine.swift
@@ -62,11 +62,11 @@ class VendingMachine: NSObject {
     /* MARK: NSSecureCoding */
     required init?(coder aDecoder: NSCoder) {
         guard let balance = aDecoder
-            .decodeObject(forKey: Keys.balance.rawValue) as? Money else { return nil }
+            .decodeObject(of: Money.self, forKey: Keys.balance.rawValue) else { return nil }
         guard let inventory = aDecoder
-            .decodeObject(forKey: Keys.inventory.rawValue) as? Inventory else { return nil }
+            .decodeObject(of: Inventory.self, forKey: Keys.inventory.rawValue) else { return nil }
         guard let history = aDecoder
-            .decodeObject(forKey: Keys.history.rawValue) as? History else { return nil }
+            .decodeObject(of: History.self, forKey: Keys.history.rawValue) else { return nil }
         self.balance = balance
         self.inventory = inventory
         self.history = history

--- a/VendingMachineApp/VendingMachineApp/VendingMachineArchiver.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachineArchiver.swift
@@ -1,0 +1,39 @@
+//
+//  File.swift
+//  VendingMachineApp
+//
+//  Created by 윤지영 on 08/01/2019.
+//  Copyright © 2019 윤지영. All rights reserved.
+//
+
+import Foundation
+
+struct VendingMachineArchiver {
+
+    enum ArchivingError: Error {
+        case noData
+        case notLoaded
+    }
+
+    static func archive(vendingMachine: VendingMachine?) {
+        guard let vendingMachine = vendingMachine else { return }
+        let vendingMachineEncoded = try? NSKeyedArchiver.archivedData(
+            withRootObject: vendingMachine,
+            requiringSecureCoding: false)
+        UserDefaults.standard.set(vendingMachineEncoded, forKey:"vendingMachine")
+    }
+
+    static func load() throws -> VendingMachine {
+        guard let data = UserDefaults.standard.data(forKey: "vendingMachine") else { throw ArchivingError.noData }
+        guard let vendingMachine = try NSKeyedUnarchiver
+            .unarchiveTopLevelObjectWithData(data) as? VendingMachine else { throw ArchivingError.notLoaded }
+        return vendingMachine
+    }
+
+    static func setDefault() -> VendingMachine {
+        let money = Money()
+        let inventory = Inventory(list: [ObjectIdentifier: Pack]())
+        return VendingMachine.init(initialBalance: money, initialInventory: inventory)
+    }
+
+}

--- a/VendingMachineApp/VendingMachineApp/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/ViewController.swift
@@ -9,16 +9,21 @@
 import UIKit
 
 class ViewController: UIViewController {
-    private var vendingMachine: VendingMachine
+    private var appDelegate: AppDelegate?
     @IBOutlet var beverageImages: [UIImageView]!
     @IBOutlet var beverageLabels: [UILabel]!
     @IBOutlet weak var balance: UILabel!
 
     required init?(coder aDecoder: NSCoder) {
+        self.appDelegate = UIApplication.shared.delegate as? AppDelegate
+        super.init(coder: aDecoder)
+        setVendingMachine()
+    }
+
+    private func setVendingMachine() {
         let emptyList = [ObjectIdentifier: Pack]()
         let inventory = Inventory(list: emptyList)
-        self.vendingMachine = VendingMachine(initialInventory: inventory)
-        super.init(coder: aDecoder)
+        appDelegate?.vendingMachine = VendingMachine(initialInventory: inventory)
     }
 
     private func roundImageViews() {
@@ -32,12 +37,12 @@ class ViewController: UIViewController {
         super.viewDidLoad()
         roundImageViews()
         showQuantities()
-        vendingMachine.showBalance(with: balanceForm)
+        appDelegate?.vendingMachine?.showBalance(with: balanceForm)
     }
 
     private func showQuantities() {
         for (index, quantity) in beverageLabels.enumerated() {
-            if let count = vendingMachine.count(beverage: index) {
+            if let count =  appDelegate?.vendingMachine?.count(beverage: index) {
                 quantity.text = "\(count)개"
                 continue
             }
@@ -47,7 +52,7 @@ class ViewController: UIViewController {
 
     @IBAction func addBeverage(_ sender: UIButton) {
         guard let beverage = BeverageSubCategory(rawValue: sender.tag) else { return }
-        guard vendingMachine.add(beverage: beverage) else { return }
+        guard appDelegate?.vendingMachine?.add(beverage: beverage) ?? false else { return }
         showQuantities()
     }
 
@@ -56,8 +61,8 @@ class ViewController: UIViewController {
     }
 
     private func insert(money: Money) {
-        guard vendingMachine.insert(money: money) else { return }
-        vendingMachine.showBalance(with: balanceForm)
+        guard appDelegate?.vendingMachine?.insert(money: money) ?? false else { return }
+        appDelegate?.vendingMachine?.showBalance(with: balanceForm)
     }
 
     @IBAction func insertOneThousand(_ sender: Any) {

--- a/VendingMachineApp/VendingMachineApp/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/ViewController.swift
@@ -17,13 +17,6 @@ class ViewController: UIViewController {
     required init?(coder aDecoder: NSCoder) {
         self.appDelegate = UIApplication.shared.delegate as? AppDelegate
         super.init(coder: aDecoder)
-        setVendingMachine()
-    }
-
-    private func setVendingMachine() {
-        let emptyList = [ObjectIdentifier: Pack]()
-        let inventory = Inventory(list: emptyList)
-        appDelegate?.vendingMachine = VendingMachine(initialInventory: inventory)
     }
 
     private func roundImageViews() {

--- a/VendingMachineApp/VendingMachineApp/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/ViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 class ViewController: UIViewController {
-    private var appDelegate: AppDelegate?
+    private weak var appDelegate: AppDelegate?
     @IBOutlet var beverageImages: [UIImageView]!
     @IBOutlet var beverageLabels: [UILabel]!
     @IBOutlet weak var balance: UILabel!

--- a/VendingMachineApp/VendingMachineApp/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/ViewController.swift
@@ -55,22 +55,17 @@ class ViewController: UIViewController {
         self.balance.text = "잔액: \(money)원"
     }
 
-    private enum Money: Int {
-        case oneThousand = 1000
-        case fiveThousands = 5000
-    }
-
     private func insert(money: Money) {
-        guard vendingMachine.insert(money: money.rawValue) else { return }
+        guard vendingMachine.insert(money: money) else { return }
         vendingMachine.showBalance(with: balanceForm)
     }
 
     @IBAction func insertOneThousand(_ sender: Any) {
-        insert(money: .oneThousand)
+        insert(money: Money(unit: .oneThousand))
     }
 
     @IBAction func insertFiveThousands(_ sender: Any) {
-        insert(money: .fiveThousands)
+        insert(money: Money(unit: .fiveThousands))
     }
 
 }


### PR DESCRIPTION
- `VendingMachine` 객체를 `ViewController` 에서 `AppDelegate` 로 옮긴 후, `ViewController` 에서는 `UIApplication` 의 `delegate` 변수를 통해 접근하도록 수정했습니다.
- `VendingMachine` 객체를 인코딩하기 위해, 관련 클래스 객체가 모두 `NSSecureCoding` 프로토콜을 채택하여 인코드, 디코드를 지원하도록 추가했습니다.
- `NSKeyedArchiver` 와 `NSKeyedUnarchiver` 를 통해 자판기 객체를 `Data` 로 아카이브/언아카이브하고, `UserDefaults` 객체에 set/get 하도록 추가했습니다. 해당 기능을 담당하는 `VendingMachineArchiver` 구조체를 생성하여, `AppDelegate` 구현부에서 분리하였습니다.
- 구현하면서 학습한 내용 및 실행화면 이미지를 README에 정리했습니다.