### PR TITLE
자판기 앱 7단계 - Frame과 Bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 4. <a href="#4-싱글톤-모델">싱글톤 모델</a>
 5. <a href="#5-관찰자(Observer)-패턴">관찰자(Observer) 패턴</a>
 6. <a href="#6-구매목록-View-코드">구매목록 View 코드</a>
+7. <a href="#7-Frame과-Bounds">Frame과 Bounds</a>
 
 <br>
 
@@ -517,6 +518,46 @@ var masksToBounds: Bool { get set }
 
 <br>
 
-### 추가학습
+## 7. Frame과 Bounds
+
+### 추가내용
+
+##### 1. `AdminViewController` 추가
+
+자판기 앱을 사용자모드와 관리자모드로 구분하여 사용하고자, 기존 뷰 컨트롤러는 `UserViewController` 로 명명하고 `AdminViewController` 라는 새로운 뷰 컨트롤러를 추가했습니다. `UserViewController` 에 `Info Light` 타입의 버튼을 추가하고, 추가한 뷰 컨트롤러로 Segue를 연결했습니다.
+
+각 뷰 컨트롤러의 `vendingMachine` 프로퍼티의 타입을 각각 `UserMode` , `AdminMode` 로 변경해주었습니다. Segue 전에 호출되는 `prepare()` 메소드에서 `AdminMode` 로 타입캐스팅한 자판기 객체의 인스턴스를 넘겨주도록 추가했습니다.
+
+```swift
+class UserViewController: UIViewController {
+    private weak var vendingMachine: UserMode?
+    ...
+    
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        guard let adminViewController = segue.destination as? AdminViewController else { return }
+        guard let vendingMachine = vendingMachine as? AdminMode else { return }
+        adminViewController.set(vendingMachine: vendingMachine)
+    }
+}
+
+class AdminViewController: UIViewController {
+    private weak var vendingMachine: AdminMode?
+    ...
+}
+```
+
+또한, `AdminViewController` 에 `닫기` 버튼을 추가하고 클릭 시 해당 뷰 컨트롤러를 `dismiss()` 를 호출하도록 추가했습니다.
 
 <br>
+
+##### 2. 재고 추가 기능 이동
+
+기존 `ViewController` 에 `음료구매`/`잔액추가` 기능과 같이 있던 `음료추가` 기능을 `AdminViewController` 로 이동해주었습니다. 특정 동작 후 업데이트 되어야할 레이블이 재고 레이블밖에 없으므로, `inventoryDataChanged` 노티피케이션의 관찰자 역할만 추가해주었습니다.
+
+<br>
+
+### 실행화면
+
+> 완성일자: 2019.01.17 18:08
+
+![Jan-17-2019](./images/step7/Jan-17-2019.gif)

--- a/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
+++ b/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
@@ -14,7 +14,7 @@
 		A3040F4D21EC58C500B9A831 /* Georgia.jpg in Resources */ = {isa = PBXBuildFile; fileRef = A3040F4C21EC58C500B9A831 /* Georgia.jpg */; };
 		A3C9671421F04933001E6F08 /* AdminViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C9671321F04933001E6F08 /* AdminViewController.swift */; };
 		A3E1B2EA21CFE07A00B35A96 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E1B2E921CFE07A00B35A96 /* AppDelegate.swift */; };
-		A3E1B2EC21CFE07A00B35A96 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E1B2EB21CFE07A00B35A96 /* ViewController.swift */; };
+		A3E1B2EC21CFE07A00B35A96 /* UserViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E1B2EB21CFE07A00B35A96 /* UserViewController.swift */; };
 		A3E1B2EF21CFE07A00B35A96 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A3E1B2ED21CFE07A00B35A96 /* Main.storyboard */; };
 		A3E1B2F121CFE07C00B35A96 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A3E1B2F021CFE07C00B35A96 /* Assets.xcassets */; };
 		A3E1B2F421CFE07C00B35A96 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A3E1B2F221CFE07C00B35A96 /* LaunchScreen.storyboard */; };
@@ -71,7 +71,7 @@
 		A3C9671321F04933001E6F08 /* AdminViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminViewController.swift; sourceTree = "<group>"; };
 		A3E1B2E621CFE07900B35A96 /* VendingMachineApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = VendingMachineApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A3E1B2E921CFE07A00B35A96 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		A3E1B2EB21CFE07A00B35A96 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		A3E1B2EB21CFE07A00B35A96 /* UserViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserViewController.swift; sourceTree = "<group>"; };
 		A3E1B2EE21CFE07A00B35A96 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		A3E1B2F021CFE07C00B35A96 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		A3E1B2F321CFE07C00B35A96 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -166,7 +166,7 @@
 				A3040F4921E84DAA00B9A831 /* CustomView */,
 				A3E1B33521D06F1F00B35A96 /* VendingMachine */,
 				A3E1B2E921CFE07A00B35A96 /* AppDelegate.swift */,
-				A3E1B2EB21CFE07A00B35A96 /* ViewController.swift */,
+				A3E1B2EB21CFE07A00B35A96 /* UserViewController.swift */,
 				A3C9671321F04933001E6F08 /* AdminViewController.swift */,
 				A3E1B2ED21CFE07A00B35A96 /* Main.storyboard */,
 				A3E1B2F021CFE07C00B35A96 /* Assets.xcassets */,
@@ -407,7 +407,7 @@
 			files = (
 				A3E1B33D21D06F2000B35A96 /* History.swift in Sources */,
 				A3E1B35421D0712C00B35A96 /* StrawberryMilk.swift in Sources */,
-				A3E1B2EC21CFE07A00B35A96 /* ViewController.swift in Sources */,
+				A3E1B2EC21CFE07A00B35A96 /* UserViewController.swift in Sources */,
 				A3040F4B21E84E6D00B9A831 /* RoundedCornersImageView.swift in Sources */,
 				A3E1B35321D0712C00B35A96 /* Beverage.swift in Sources */,
 				A3E1B35A21D0712C00B35A96 /* BeverageCategory.swift in Sources */,

--- a/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
+++ b/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		A3040F4821E448DB00B9A831 /* VendingMachineArchiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3040F4721E448DB00B9A831 /* VendingMachineArchiver.swift */; };
 		A3040F4B21E84E6D00B9A831 /* RoundedCornersImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3040F4A21E84E6D00B9A831 /* RoundedCornersImageView.swift */; };
 		A3040F4D21EC58C500B9A831 /* Georgia.jpg in Resources */ = {isa = PBXBuildFile; fileRef = A3040F4C21EC58C500B9A831 /* Georgia.jpg */; };
+		A3C9671421F04933001E6F08 /* AdminViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C9671321F04933001E6F08 /* AdminViewController.swift */; };
 		A3E1B2EA21CFE07A00B35A96 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E1B2E921CFE07A00B35A96 /* AppDelegate.swift */; };
 		A3E1B2EC21CFE07A00B35A96 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E1B2EB21CFE07A00B35A96 /* ViewController.swift */; };
 		A3E1B2EF21CFE07A00B35A96 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A3E1B2ED21CFE07A00B35A96 /* Main.storyboard */; };
@@ -67,6 +68,7 @@
 		A3040F4721E448DB00B9A831 /* VendingMachineArchiver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VendingMachineArchiver.swift; sourceTree = "<group>"; };
 		A3040F4A21E84E6D00B9A831 /* RoundedCornersImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedCornersImageView.swift; sourceTree = "<group>"; };
 		A3040F4C21EC58C500B9A831 /* Georgia.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = Georgia.jpg; sourceTree = "<group>"; };
+		A3C9671321F04933001E6F08 /* AdminViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminViewController.swift; sourceTree = "<group>"; };
 		A3E1B2E621CFE07900B35A96 /* VendingMachineApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = VendingMachineApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A3E1B2E921CFE07A00B35A96 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A3E1B2EB21CFE07A00B35A96 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -165,6 +167,7 @@
 				A3E1B33521D06F1F00B35A96 /* VendingMachine */,
 				A3E1B2E921CFE07A00B35A96 /* AppDelegate.swift */,
 				A3E1B2EB21CFE07A00B35A96 /* ViewController.swift */,
+				A3C9671321F04933001E6F08 /* AdminViewController.swift */,
 				A3E1B2ED21CFE07A00B35A96 /* Main.storyboard */,
 				A3E1B2F021CFE07C00B35A96 /* Assets.xcassets */,
 				A3E1B2F221CFE07C00B35A96 /* LaunchScreen.storyboard */,
@@ -425,6 +428,7 @@
 				A3E1B35F21D0712C00B35A96 /* BeverageGroup.swift in Sources */,
 				A3E1B35C21D0712C00B35A96 /* Cantata.swift in Sources */,
 				A3E1B35721D0712C00B35A96 /* Sprite.swift in Sources */,
+				A3C9671421F04933001E6F08 /* AdminViewController.swift in Sources */,
 				A3E1B33C21D06F2000B35A96 /* VendingMachine.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/VendingMachineApp/VendingMachineApp/AdminViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/AdminViewController.swift
@@ -48,7 +48,7 @@ class AdminViewController: UIViewController {
         updateAllQuantityLabels()
     }
 
-    @IBAction func addBeverage(_ sender: UIButton) {
+    @IBAction func addBeverageButtonTouched(_ sender: UIButton) {
         guard let beverage = BeverageSubCategory(rawValue: sender.tag) else { return }
         guard let vendingMachine = vendingMachine else { return }
         vendingMachine.add(beverage: beverage)

--- a/VendingMachineApp/VendingMachineApp/AdminViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/AdminViewController.swift
@@ -12,7 +12,7 @@ class AdminViewController: UIViewController {
     @IBOutlet var beverageImages: [RoundedCornersImageView]!
     @IBOutlet var beverageLabels: [UILabel]!
 
-    private weak var vendingMachine: VendingMachine?
+    private weak var vendingMachine: AdminMode?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -20,7 +20,7 @@ class AdminViewController: UIViewController {
         updateAllQuantityLabels()
     }
 
-    func set(vendingMachine: VendingMachine) {
+    func set(vendingMachine: AdminMode?) {
         self.vendingMachine = vendingMachine
     }
 

--- a/VendingMachineApp/VendingMachineApp/AdminViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/AdminViewController.swift
@@ -9,22 +9,52 @@
 import UIKit
 
 class AdminViewController: UIViewController {
+    @IBOutlet var beverageImages: [RoundedCornersImageView]!
+    @IBOutlet var beverageLabels: [UILabel]!
+
+    private weak var vendingMachine: VendingMachine?
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+        registerAsObserver()
     }
-    
 
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    override func viewWillAppear(_ animated: Bool) {
+        updateAllQuantityLabels()
     }
-    */
+
+    func set(vendingMachine: VendingMachine) {
+        self.vendingMachine = vendingMachine
+    }
+
+    private func registerAsObserver() {
+        let center = NotificationCenter.default
+        center.addObserver(self, selector: #selector(showQuantities(_:)), name: .inventoryDataChanged, object: nil)
+    }
+
+    private func updateOneQuantityLabel(of index: Int) {
+        let count =  vendingMachine?.count(beverage: index)
+        beverageLabels[index].text = "\(count ?? 0)개"
+    }
+
+    private func updateAllQuantityLabels() {
+        for index in beverageLabels.indices {
+            updateOneQuantityLabel(of: index)
+        }
+    }
+
+    @objc private func showQuantities(_ notification: Notification) {
+        if let index = notification.userInfo?[Notification.InfoKey.indexOfBeverage] as? Int {
+            updateOneQuantityLabel(of: index)
+            return
+        }
+        updateAllQuantityLabels()
+    }
+
+    @IBAction func addBeverage(_ sender: UIButton) {
+        guard let beverage = BeverageSubCategory(rawValue: sender.tag) else { return }
+        guard let vendingMachine = vendingMachine else { return }
+        vendingMachine.add(beverage: beverage)
+    }
 
 }

--- a/VendingMachineApp/VendingMachineApp/AdminViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/AdminViewController.swift
@@ -41,7 +41,7 @@ class AdminViewController: UIViewController {
     }
 
     @objc private func showQuantities(_ notification: Notification) {
-        if let index = notification.userInfo?[Notification.InfoKey.indexOfBeverage] as? Int {
+        if let index = notification.userInfo?[Notification.InfoKey.numberValueOfBeverage] as? Int {
             updateOneQuantityLabel(of: index)
             return
         }

--- a/VendingMachineApp/VendingMachineApp/AdminViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/AdminViewController.swift
@@ -1,0 +1,30 @@
+//
+//  AdminViewController.swift
+//  VendingMachineApp
+//
+//  Created by 윤지영 on 17/01/2019.
+//  Copyright © 2019 윤지영. All rights reserved.
+//
+
+import UIKit
+
+class AdminViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/VendingMachineApp/VendingMachineApp/AdminViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/AdminViewController.swift
@@ -17,9 +17,6 @@ class AdminViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         registerAsObserver()
-    }
-
-    override func viewWillAppear(_ animated: Bool) {
         updateAllQuantityLabels()
     }
 
@@ -55,6 +52,10 @@ class AdminViewController: UIViewController {
         guard let beverage = BeverageSubCategory(rawValue: sender.tag) else { return }
         guard let vendingMachine = vendingMachine else { return }
         vendingMachine.add(beverage: beverage)
+    }
+
+    @IBAction func closeButtonTouched(_ sender: Any) {
+        self.dismiss(animated: true, completion: nil)
     }
 
 }

--- a/VendingMachineApp/VendingMachineApp/AppDelegate.swift
+++ b/VendingMachineApp/VendingMachineApp/AppDelegate.swift
@@ -13,8 +13,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        let viewController = window?.rootViewController as? ViewController
-        viewController?.set(vendingMachine: VendingMachine.shared)
+        let viewController = window?.rootViewController as? UserViewController
+        viewController?.set(vendingMachine: VendingMachine.shared as? UserMode)
         return true
     }
 

--- a/VendingMachineApp/VendingMachineApp/Base.lproj/Main.storyboard
+++ b/VendingMachineApp/VendingMachineApp/Base.lproj/Main.storyboard
@@ -42,54 +42,6 @@
                                 <rect key="frame" x="787" y="124" width="130" height="150"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             </imageView>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lXJ-w4-Abj">
-                                <rect key="frame" x="87" y="86" width="30" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="추가"/>
-                                <connections>
-                                    <action selector="addBeverage:" destination="BYZ-38-t0r" eventType="touchUpInside" id="shd-tS-qZP"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" tag="4" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Uex-rP-8OG">
-                                <rect key="frame" x="687" y="86" width="30" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="추가"/>
-                                <connections>
-                                    <action selector="addBeverage:" destination="BYZ-38-t0r" eventType="touchUpInside" id="wrA-nI-gHA"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" tag="3" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5Us-0E-Ua4">
-                                <rect key="frame" x="537" y="86" width="30" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="추가"/>
-                                <connections>
-                                    <action selector="addBeverage:" destination="BYZ-38-t0r" eventType="touchUpInside" id="yH8-83-IeS"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" tag="1" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="t84-1Q-dZv">
-                                <rect key="frame" x="237" y="86" width="30" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="추가"/>
-                                <connections>
-                                    <action selector="addBeverage:" destination="BYZ-38-t0r" eventType="touchUpInside" id="cvE-oL-4bJ"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" tag="2" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XmG-73-scn">
-                                <rect key="frame" x="387" y="86" width="30" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="추가"/>
-                                <connections>
-                                    <action selector="addBeverage:" destination="BYZ-38-t0r" eventType="touchUpInside" id="M5O-fd-Iob"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" tag="5" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="09U-Ss-jLf">
-                                <rect key="frame" x="837" y="86" width="30" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="추가"/>
-                                <connections>
-                                    <action selector="addBeverage:" destination="BYZ-38-t0r" eventType="touchUpInside" id="kf7-Ga-KL3"/>
-                                </connections>
-                            </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UDH-3S-KoH">
                                 <rect key="frame" x="231" y="282" width="42" height="21"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
@@ -241,9 +193,146 @@
                     <view key="view" contentMode="scaleToFill" id="6rC-vu-7CO">
                         <rect key="frame" x="0.0" y="0.0" width="1112" height="834"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="ChocolateMilk.jpg" translatesAutoresizingMaskIntoConstraints="NO" id="1SR-As-0mf" customClass="RoundedCornersImageView" customModule="VendingMachineApp" customModuleProvider="target">
+                                <rect key="frame" x="37" y="124" width="130" height="150"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            </imageView>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="StrawberryMilk.jpg" translatesAutoresizingMaskIntoConstraints="NO" id="01M-Da-ce5" customClass="RoundedCornersImageView" customModule="VendingMachineApp" customModuleProvider="target">
+                                <rect key="frame" x="187" y="124" width="130" height="150"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            </imageView>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="Sprite.jpg" translatesAutoresizingMaskIntoConstraints="NO" id="9cF-qp-st3" customClass="RoundedCornersImageView" customModule="VendingMachineApp" customModuleProvider="target">
+                                <rect key="frame" x="337" y="124" width="130" height="150"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            </imageView>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="Pepsi.jpg" translatesAutoresizingMaskIntoConstraints="NO" id="soY-5Z-0A2" customClass="RoundedCornersImageView" customModule="VendingMachineApp" customModuleProvider="target">
+                                <rect key="frame" x="487" y="124" width="130" height="150"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            </imageView>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="Cantata.jpg" translatesAutoresizingMaskIntoConstraints="NO" id="YFO-OR-vWT" customClass="RoundedCornersImageView" customModule="VendingMachineApp" customModuleProvider="target">
+                                <rect key="frame" x="637" y="124" width="130" height="150"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            </imageView>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="Georgia.jpg" translatesAutoresizingMaskIntoConstraints="NO" id="rtl-kU-C8p" customClass="RoundedCornersImageView" customModule="VendingMachineApp" customModuleProvider="target">
+                                <rect key="frame" x="787" y="124" width="130" height="150"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            </imageView>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Lfn-ZP-r8n">
+                                <rect key="frame" x="87" y="86" width="30" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="추가"/>
+                                <connections>
+                                    <action selector="addBeverage:" destination="BYZ-38-t0r" eventType="touchUpInside" id="JnS-jw-mRE"/>
+                                    <action selector="addBeverage:" destination="Qyu-07-8h8" eventType="touchUpInside" id="Uae-9h-c4R"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" tag="4" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Moe-0T-F6R">
+                                <rect key="frame" x="687" y="86" width="30" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="추가"/>
+                                <connections>
+                                    <action selector="addBeverage:" destination="BYZ-38-t0r" eventType="touchUpInside" id="EVj-RO-auN"/>
+                                    <action selector="addBeverage:" destination="Qyu-07-8h8" eventType="touchUpInside" id="hIe-rE-q33"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" tag="3" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JNF-Uq-6zh">
+                                <rect key="frame" x="537" y="86" width="30" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="추가"/>
+                                <connections>
+                                    <action selector="addBeverage:" destination="Qyu-07-8h8" eventType="touchUpInside" id="bID-eq-3qz"/>
+                                    <action selector="addBeverage:" destination="BYZ-38-t0r" eventType="touchUpInside" id="xBx-e2-ozN"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" tag="1" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bjO-o1-j5k">
+                                <rect key="frame" x="237" y="86" width="30" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="추가"/>
+                                <connections>
+                                    <action selector="addBeverage:" destination="BYZ-38-t0r" eventType="touchUpInside" id="hUz-Ht-2lC"/>
+                                    <action selector="addBeverage:" destination="Qyu-07-8h8" eventType="touchUpInside" id="xq0-bP-z4K"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" tag="2" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NSt-yl-YlT">
+                                <rect key="frame" x="387" y="86" width="30" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="추가"/>
+                                <connections>
+                                    <action selector="addBeverage:" destination="BYZ-38-t0r" eventType="touchUpInside" id="BWS-zM-N1t"/>
+                                    <action selector="addBeverage:" destination="Qyu-07-8h8" eventType="touchUpInside" id="GGQ-Rc-cUe"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" tag="5" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vKx-d1-qdU">
+                                <rect key="frame" x="837" y="86" width="30" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="추가"/>
+                                <connections>
+                                    <action selector="addBeverage:" destination="BYZ-38-t0r" eventType="touchUpInside" id="7HM-UQ-fuL"/>
+                                    <action selector="addBeverage:" destination="Qyu-07-8h8" eventType="touchUpInside" id="cjK-29-J1E"/>
+                                </connections>
+                            </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6vR-fy-vgi">
+                                <rect key="frame" x="231" y="282" width="42" height="21"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YT8-7T-vIL">
+                                <rect key="frame" x="681" y="282" width="42" height="21"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dmB-2E-6Tu">
+                                <rect key="frame" x="535" y="282" width="42" height="21"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="43e-dP-n1n">
+                                <rect key="frame" x="381" y="282" width="42" height="21"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="a8C-Cl-srM">
+                                <rect key="frame" x="81" y="282" width="42" height="21"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MP5-Ht-AHl">
+                                <rect key="frame" x="831" y="282" width="42" height="21"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <viewLayoutGuide key="safeArea" id="t8D-gs-kO6"/>
                     </view>
+                    <connections>
+                        <outletCollection property="beverageImages" destination="1SR-As-0mf" collectionClass="NSMutableArray" id="cxq-fB-D3C"/>
+                        <outletCollection property="beverageImages" destination="01M-Da-ce5" collectionClass="NSMutableArray" id="Mfs-S9-cNK"/>
+                        <outletCollection property="beverageImages" destination="9cF-qp-st3" collectionClass="NSMutableArray" id="lJQ-2x-8hU"/>
+                        <outletCollection property="beverageImages" destination="soY-5Z-0A2" collectionClass="NSMutableArray" id="4jd-4i-OkX"/>
+                        <outletCollection property="beverageImages" destination="YFO-OR-vWT" collectionClass="NSMutableArray" id="lBw-qR-UMp"/>
+                        <outletCollection property="beverageImages" destination="rtl-kU-C8p" collectionClass="NSMutableArray" id="bcD-cL-jLi"/>
+                        <outletCollection property="beverageLabels" destination="a8C-Cl-srM" collectionClass="NSMutableArray" id="ozy-yy-lJb"/>
+                        <outletCollection property="beverageLabels" destination="6vR-fy-vgi" collectionClass="NSMutableArray" id="jTn-0u-stR"/>
+                        <outletCollection property="beverageLabels" destination="43e-dP-n1n" collectionClass="NSMutableArray" id="mfR-d6-JaU"/>
+                        <outletCollection property="beverageLabels" destination="dmB-2E-6Tu" collectionClass="NSMutableArray" id="QUr-3J-jMK"/>
+                        <outletCollection property="beverageLabels" destination="YT8-7T-vIL" collectionClass="NSMutableArray" id="9NU-Yv-kaw"/>
+                        <outletCollection property="beverageLabels" destination="YT8-7T-vIL" collectionClass="NSMutableArray" id="r3N-gL-1TZ"/>
+                        <outletCollection property="beverageLabels" destination="MP5-Ht-AHl" collectionClass="NSMutableArray" id="zCq-lk-uMd"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="OIX-Qe-eLI" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>

--- a/VendingMachineApp/VendingMachineApp/Base.lproj/Main.storyboard
+++ b/VendingMachineApp/VendingMachineApp/Base.lproj/Main.storyboard
@@ -314,6 +314,14 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YFq-re-TEh">
+                                <rect key="frame" x="1008" y="55" width="30" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="닫기"/>
+                                <connections>
+                                    <action selector="closeButtonTouched:" destination="Qyu-07-8h8" eventType="touchUpInside" id="peC-Ql-txt"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <viewLayoutGuide key="safeArea" id="t8D-gs-kO6"/>
@@ -330,7 +338,6 @@
                         <outletCollection property="beverageLabels" destination="43e-dP-n1n" collectionClass="NSMutableArray" id="mfR-d6-JaU"/>
                         <outletCollection property="beverageLabels" destination="dmB-2E-6Tu" collectionClass="NSMutableArray" id="QUr-3J-jMK"/>
                         <outletCollection property="beverageLabels" destination="YT8-7T-vIL" collectionClass="NSMutableArray" id="9NU-Yv-kaw"/>
-                        <outletCollection property="beverageLabels" destination="YT8-7T-vIL" collectionClass="NSMutableArray" id="r3N-gL-1TZ"/>
                         <outletCollection property="beverageLabels" destination="MP5-Ht-AHl" collectionClass="NSMutableArray" id="zCq-lk-uMd"/>
                     </connections>
                 </viewController>

--- a/VendingMachineApp/VendingMachineApp/Base.lproj/Main.storyboard
+++ b/VendingMachineApp/VendingMachineApp/Base.lproj/Main.storyboard
@@ -323,7 +323,7 @@
                                 </connections>
                             </button>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <color key="backgroundColor" red="0.93725490570000003" green="0.93725490570000003" blue="0.95686274770000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <viewLayoutGuide key="safeArea" id="t8D-gs-kO6"/>
                     </view>
                     <connections>

--- a/VendingMachineApp/VendingMachineApp/Base.lproj/Main.storyboard
+++ b/VendingMachineApp/VendingMachineApp/Base.lproj/Main.storyboard
@@ -203,6 +203,13 @@
                                     <action selector="buyBeverage:" destination="BYZ-38-t0r" eventType="touchUpInside" id="fRB-fF-U8I"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="infoLight" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pdS-a6-FRg">
+                                <rect key="frame" x="1040" y="55" width="22" height="22"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <connections>
+                                    <segue destination="Qyu-07-8h8" kind="presentation" modalTransitionStyle="flipHorizontal" id="tWa-B3-34C"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
@@ -226,6 +233,21 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="69.60431654676259" y="23.741007194244606"/>
+        </scene>
+        <!--Admin View Controller-->
+        <scene sceneID="pU9-1L-V59">
+            <objects>
+                <viewController id="Qyu-07-8h8" customClass="AdminViewController" customModule="VendingMachineApp" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="6rC-vu-7CO">
+                        <rect key="frame" x="0.0" y="0.0" width="1112" height="834"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <viewLayoutGuide key="safeArea" id="t8D-gs-kO6"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="OIX-Qe-eLI" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="754" y="24"/>
         </scene>
     </scenes>
     <resources>

--- a/VendingMachineApp/VendingMachineApp/Base.lproj/Main.storyboard
+++ b/VendingMachineApp/VendingMachineApp/Base.lproj/Main.storyboard
@@ -89,7 +89,7 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="+1000"/>
                                 <connections>
-                                    <action selector="insertMoney:" destination="BYZ-38-t0r" eventType="touchUpInside" id="WdW-oX-JiR"/>
+                                    <action selector="insertMoneyButtonTouched:" destination="BYZ-38-t0r" eventType="touchUpInside" id="WdW-oX-JiR"/>
                                 </connections>
                             </button>
                             <button opaque="NO" tag="5000" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VOv-Ej-Zuj">
@@ -97,7 +97,7 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="+5000"/>
                                 <connections>
-                                    <action selector="insertMoney:" destination="BYZ-38-t0r" eventType="touchUpInside" id="HA6-xf-viv"/>
+                                    <action selector="insertMoneyButtonTouched:" destination="BYZ-38-t0r" eventType="touchUpInside" id="HA6-xf-viv"/>
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="잔액" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="07q-vr-3Fk">
@@ -112,7 +112,7 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="구매"/>
                                 <connections>
-                                    <action selector="buyBeverage:" destination="BYZ-38-t0r" eventType="touchUpInside" id="VdV-Up-RhG"/>
+                                    <action selector="buyBeverageButtonTouched:" destination="BYZ-38-t0r" eventType="touchUpInside" id="VdV-Up-RhG"/>
                                 </connections>
                             </button>
                             <button opaque="NO" tag="1" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3EJ-pJ-GR4">
@@ -120,7 +120,7 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="구매"/>
                                 <connections>
-                                    <action selector="buyBeverage:" destination="BYZ-38-t0r" eventType="touchUpInside" id="70f-yx-iAk"/>
+                                    <action selector="buyBeverageButtonTouched:" destination="BYZ-38-t0r" eventType="touchUpInside" id="70f-yx-iAk"/>
                                 </connections>
                             </button>
                             <button opaque="NO" tag="4" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5uv-mH-hra">
@@ -128,7 +128,7 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="구매"/>
                                 <connections>
-                                    <action selector="buyBeverage:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Vxz-SB-tHl"/>
+                                    <action selector="buyBeverageButtonTouched:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Vxz-SB-tHl"/>
                                 </connections>
                             </button>
                             <button opaque="NO" tag="2" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ifm-Rs-Qtq">
@@ -136,7 +136,7 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="구매"/>
                                 <connections>
-                                    <action selector="buyBeverage:" destination="BYZ-38-t0r" eventType="touchUpInside" id="6IX-Ug-owC"/>
+                                    <action selector="buyBeverageButtonTouched:" destination="BYZ-38-t0r" eventType="touchUpInside" id="6IX-Ug-owC"/>
                                 </connections>
                             </button>
                             <button opaque="NO" tag="3" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tMz-Kj-yt0">
@@ -144,7 +144,7 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="구매"/>
                                 <connections>
-                                    <action selector="buyBeverage:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Eau-Xu-HoJ"/>
+                                    <action selector="buyBeverageButtonTouched:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Eau-Xu-HoJ"/>
                                 </connections>
                             </button>
                             <button opaque="NO" tag="5" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="18T-bY-vOL">
@@ -152,7 +152,7 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="구매"/>
                                 <connections>
-                                    <action selector="buyBeverage:" destination="BYZ-38-t0r" eventType="touchUpInside" id="fRB-fF-U8I"/>
+                                    <action selector="buyBeverageButtonTouched:" destination="BYZ-38-t0r" eventType="touchUpInside" id="fRB-fF-U8I"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="infoLight" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pdS-a6-FRg">
@@ -224,7 +224,7 @@
                                 <state key="normal" title="추가"/>
                                 <connections>
                                     <action selector="addBeverage:" destination="BYZ-38-t0r" eventType="touchUpInside" id="JnS-jw-mRE"/>
-                                    <action selector="addBeverage:" destination="Qyu-07-8h8" eventType="touchUpInside" id="Uae-9h-c4R"/>
+                                    <action selector="addBeverageButtonTouched:" destination="Qyu-07-8h8" eventType="touchUpInside" id="Uae-9h-c4R"/>
                                 </connections>
                             </button>
                             <button opaque="NO" tag="4" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Moe-0T-F6R">
@@ -233,7 +233,7 @@
                                 <state key="normal" title="추가"/>
                                 <connections>
                                     <action selector="addBeverage:" destination="BYZ-38-t0r" eventType="touchUpInside" id="EVj-RO-auN"/>
-                                    <action selector="addBeverage:" destination="Qyu-07-8h8" eventType="touchUpInside" id="hIe-rE-q33"/>
+                                    <action selector="addBeverageButtonTouched:" destination="Qyu-07-8h8" eventType="touchUpInside" id="hIe-rE-q33"/>
                                 </connections>
                             </button>
                             <button opaque="NO" tag="3" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JNF-Uq-6zh">
@@ -241,8 +241,8 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="추가"/>
                                 <connections>
-                                    <action selector="addBeverage:" destination="Qyu-07-8h8" eventType="touchUpInside" id="bID-eq-3qz"/>
                                     <action selector="addBeverage:" destination="BYZ-38-t0r" eventType="touchUpInside" id="xBx-e2-ozN"/>
+                                    <action selector="addBeverageButtonTouched:" destination="Qyu-07-8h8" eventType="touchUpInside" id="bID-eq-3qz"/>
                                 </connections>
                             </button>
                             <button opaque="NO" tag="1" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bjO-o1-j5k">
@@ -251,7 +251,7 @@
                                 <state key="normal" title="추가"/>
                                 <connections>
                                     <action selector="addBeverage:" destination="BYZ-38-t0r" eventType="touchUpInside" id="hUz-Ht-2lC"/>
-                                    <action selector="addBeverage:" destination="Qyu-07-8h8" eventType="touchUpInside" id="xq0-bP-z4K"/>
+                                    <action selector="addBeverageButtonTouched:" destination="Qyu-07-8h8" eventType="touchUpInside" id="xq0-bP-z4K"/>
                                 </connections>
                             </button>
                             <button opaque="NO" tag="2" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NSt-yl-YlT">
@@ -260,7 +260,7 @@
                                 <state key="normal" title="추가"/>
                                 <connections>
                                     <action selector="addBeverage:" destination="BYZ-38-t0r" eventType="touchUpInside" id="BWS-zM-N1t"/>
-                                    <action selector="addBeverage:" destination="Qyu-07-8h8" eventType="touchUpInside" id="GGQ-Rc-cUe"/>
+                                    <action selector="addBeverageButtonTouched:" destination="Qyu-07-8h8" eventType="touchUpInside" id="GGQ-Rc-cUe"/>
                                 </connections>
                             </button>
                             <button opaque="NO" tag="5" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vKx-d1-qdU">
@@ -269,7 +269,7 @@
                                 <state key="normal" title="추가"/>
                                 <connections>
                                     <action selector="addBeverage:" destination="BYZ-38-t0r" eventType="touchUpInside" id="7HM-UQ-fuL"/>
-                                    <action selector="addBeverage:" destination="Qyu-07-8h8" eventType="touchUpInside" id="cjK-29-J1E"/>
+                                    <action selector="addBeverageButtonTouched:" destination="Qyu-07-8h8" eventType="touchUpInside" id="cjK-29-J1E"/>
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6vR-fy-vgi">

--- a/VendingMachineApp/VendingMachineApp/Base.lproj/Main.storyboard
+++ b/VendingMachineApp/VendingMachineApp/Base.lproj/Main.storyboard
@@ -10,10 +10,10 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
+        <!--User View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="VendingMachineApp" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="UserViewController" customModule="VendingMachineApp" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="1112" height="834"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/VendingMachineApp/VendingMachineApp/UserViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/UserViewController.swift
@@ -62,13 +62,13 @@ class UserViewController: UIViewController {
         self.view.addSubview(imageView)
     }
 
-    @IBAction func buyBeverage(_ sender: UIButton) {
+    @IBAction func buyBeverageButtonTouched(_ sender: UIButton) {
         guard let beverage = BeverageSubCategory(rawValue: sender.tag) else { return }
         guard let vendingMachine = vendingMachine else { return }
         guard vendingMachine.buy(beverage: beverage) != nil else { return }
     }
 
-    @IBAction func insertMoney(_ sender: UIButton) {
+    @IBAction func insertMoneyButtonTouched(_ sender: UIButton) {
         guard let unit = Money.Unit(rawValue: sender.tag) else { return }
         guard vendingMachine?.insert(money: Money(unit: unit)) ?? false else { return }
     }

--- a/VendingMachineApp/VendingMachineApp/UserViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/UserViewController.swift
@@ -8,12 +8,12 @@
 
 import UIKit
 
-class ViewController: UIViewController {
+class UserViewController: UIViewController {
     @IBOutlet var beverageImages: [RoundedCornersImageView]!
     @IBOutlet var beverageLabels: [UILabel]!
     @IBOutlet weak var balance: UILabel!
 
-    private weak var vendingMachine: VendingMachine?
+    private weak var vendingMachine: UserMode?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -21,7 +21,7 @@ class ViewController: UIViewController {
         vendingMachine?.willAppear()
     }
 
-    func set(vendingMachine: VendingMachine) {
+    func set(vendingMachine: UserMode?) {
         self.vendingMachine = vendingMachine
     }
 
@@ -75,7 +75,7 @@ class ViewController: UIViewController {
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         guard let adminViewController = segue.destination as? AdminViewController else { return }
-        guard let vendingMachine = vendingMachine else { return }
+        guard let vendingMachine = vendingMachine as? VendingMachine else { return }
         adminViewController.set(vendingMachine: vendingMachine)
     }
 

--- a/VendingMachineApp/VendingMachineApp/UserViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/UserViewController.swift
@@ -38,7 +38,7 @@ class UserViewController: UIViewController {
     }
 
     @objc private func showQuantities(_ notification: Notification) {
-        if let index = notification.userInfo?[Notification.InfoKey.indexOfBeverage] as? Int {
+        if let index = notification.userInfo?[Notification.InfoKey.numberValueOfBeverage] as? Int {
             updateQuantityLabel(of: index)
             return
         }

--- a/VendingMachineApp/VendingMachineApp/UserViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/UserViewController.swift
@@ -75,7 +75,7 @@ class UserViewController: UIViewController {
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         guard let adminViewController = segue.destination as? AdminViewController else { return }
-        guard let vendingMachine = vendingMachine as? VendingMachine else { return }
+        guard let vendingMachine = vendingMachine as? AdminMode else { return }
         adminViewController.set(vendingMachine: vendingMachine)
     }
 

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/Inventory.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/Inventory.swift
@@ -30,7 +30,7 @@ class Inventory: NSObject {
     }
 
     func postDataChanged(index: Int) {
-        let userInfo = [Notification.InfoKey.indexOfBeverage: index]
+        let userInfo = [Notification.InfoKey.numberValueOfBeverage: index]
         postNotificationOfDataChanged(userInfo: userInfo)
     }
 
@@ -114,5 +114,5 @@ extension Notification.Name {
 }
 
 extension Notification.InfoKey {
-    static let indexOfBeverage = "indexOfBeverage"
+    static let numberValueOfBeverage = "numberValueOfBeverage"
 }

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/VendingMachine.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/VendingMachine.swift
@@ -8,13 +8,18 @@
 
 import Foundation
 
-protocol Consumer {
-    func isEmpty() -> Bool
+protocol CommonMode {
+    func count(beverage index: Int) -> Int
+}
+
+protocol UserMode: class, CommonMode {
+    func willAppear()
+    func showBalance(with form: (Int) -> Void)
     func insert(money: Money) -> Bool
     func buy(beverage: BeverageSubCategory) -> Beverage?
 }
 
-protocol Manager {
+protocol AdminMode: class, CommonMode {
     func add(beverage: BeverageSubCategory)
     func remove(beverage: Int) -> Beverage?
     func removeExpiredBeverages() -> [Beverage]
@@ -45,17 +50,6 @@ class VendingMachine: NSObject {
         } catch {
             return VendingMachine()
         }
-    }
-
-    func count(beverage index: Int) -> Int {
-        let nothing = 0
-        guard let type = BeverageSubCategory(rawValue: index)?.type else { return nothing }
-        guard let pack = inventory.packOf(type: type) else { return nothing }
-        return pack.count
-    }
-
-    func showBalance(with form: (Int) -> Void) {
-        balance.show(with: form)
     }
 
     func willAppear() {
@@ -106,10 +100,10 @@ extension VendingMachine: NSSecureCoding {
 
 }
 
-extension VendingMachine: Consumer {
+extension VendingMachine: UserMode {
 
-    func isEmpty() -> Bool {
-        return inventory.isEmpty()
+    func showBalance(with form: (Int) -> Void) {
+        balance.show(with: form)
     }
 
     func insert(money: Money) -> Bool {
@@ -130,7 +124,18 @@ extension VendingMachine: Consumer {
 
 }
 
-extension VendingMachine: Manager {
+extension VendingMachine: CommonMode {
+
+    func count(beverage index: Int) -> Int {
+        let nothing = 0
+        guard let type = BeverageSubCategory(rawValue: index)?.type else { return nothing }
+        guard let pack = inventory.packOf(type: type) else { return nothing }
+        return pack.count
+    }
+
+}
+
+extension VendingMachine: AdminMode {
 
     func add(beverage: BeverageSubCategory) {
         let newBeverage = beverage.type.init()

--- a/VendingMachineApp/VendingMachineApp/VendingMachine/VendingMachine.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine/VendingMachine.swift
@@ -100,6 +100,17 @@ extension VendingMachine: NSSecureCoding {
 
 }
 
+extension VendingMachine: CommonMode {
+    
+    func count(beverage index: Int) -> Int {
+        let nothing = 0
+        guard let type = BeverageSubCategory(rawValue: index)?.type else { return nothing }
+        guard let pack = inventory.packOf(type: type) else { return nothing }
+        return pack.count
+    }
+    
+}
+
 extension VendingMachine: UserMode {
 
     func showBalance(with form: (Int) -> Void) {
@@ -120,17 +131,6 @@ extension VendingMachine: UserMode {
         balance.deductedPrice(of: purchase)
         history.update(purchase: purchase)
         return purchase
-    }
-
-}
-
-extension VendingMachine: CommonMode {
-
-    func count(beverage index: Int) -> Int {
-        let nothing = 0
-        guard let type = BeverageSubCategory(rawValue: index)?.type else { return nothing }
-        guard let pack = inventory.packOf(type: type) else { return nothing }
-        return pack.count
     }
 
 }

--- a/VendingMachineApp/VendingMachineApp/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/ViewController.swift
@@ -18,9 +18,6 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         registerAsObserver()
-    }
-
-    override func viewWillAppear(_ animated: Bool) {
         vendingMachine?.willAppear()
     }
 

--- a/VendingMachineApp/VendingMachineApp/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/ViewController.swift
@@ -62,12 +62,6 @@ class ViewController: UIViewController {
         self.view.addSubview(imageView)
     }
 
-    @IBAction func addBeverage(_ sender: UIButton) {
-        guard let beverage = BeverageSubCategory(rawValue: sender.tag) else { return }
-        guard let vendingMachine = vendingMachine else { return }
-        vendingMachine.add(beverage: beverage)
-    }
-
     @IBAction func buyBeverage(_ sender: UIButton) {
         guard let beverage = BeverageSubCategory(rawValue: sender.tag) else { return }
         guard let vendingMachine = vendingMachine else { return }
@@ -77,6 +71,12 @@ class ViewController: UIViewController {
     @IBAction func insertMoney(_ sender: UIButton) {
         guard let unit = Money.Unit(rawValue: sender.tag) else { return }
         guard vendingMachine?.insert(money: Money(unit: unit)) ?? false else { return }
+    }
+
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        guard let adminViewController = segue.destination as? AdminViewController else { return }
+        guard let vendingMachine = vendingMachine else { return }
+        adminViewController.set(vendingMachine: vendingMachine)
     }
 
 }


### PR DESCRIPTION
- 관리자모드 화면을 담당할 `AdminViewController` 를 추가했습니다. 기존 뷰 컨트롤러는 `UserViewController` 로 수정했습니다. 음료 추가 버튼과 기능을 `AdminViewController` 로 옮겼습니다.
- 자판기 앱의 사용자모드와 관리자모드 뷰 컨트롤러를 버튼 Segue와 닫기 버튼 `dismiss()` 로 연결했습니다.
- 두 뷰 컨트롤러의 `vendingMachine` 프로퍼티의 타입을 각각 자판기 객체의 프로토콜인 `UserMode` 와 `AdminMode` 로 수정했습니다.
- 추가한 내용과 실행화면 이미지를 README에 추가했습니다.