### PR TITLE
자판기 앱 9단계 - 마무리하기 (터치이벤트)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 5. <a href="#5-관찰자(Observer)-패턴">관찰자(Observer) 패턴</a>
 6. <a href="#6-구매목록-View-코드">구매목록 View 코드</a>
 7. <a href="#7-Frame과-Bounds">Frame과 Bounds</a>
-8. <a href="#8-코어-그래픽스(Core-Graphics)">코어 그래픽스(Core Graphics)</a>
+8. <a href="#8-코어-그래픽스core-graphics">코어 그래픽스(Core Graphics)</a>
+9. <a href="#9-마무리하기---터치이벤트">마무리하기 - 터치이벤트</a>
 
 <br>
 
@@ -663,3 +664,69 @@ UIBezierPath(arcCenter: CGPoint,
 - `addLine(to: CGPoint)` : 따라서, 위 path에 이 메소드를 호출해주면 현재 포인트에서 파라미터로 넘겨주는 포인트까지 선이 그려집니다.
 -  `fill()` : 이 메소드를 호출하는 path가 감싸고 있는 영역을 현재 지정된 컬러로 채워줍니다.
   - `UIColor.setFill()` : 해당 컬러를 fill color로 지정해줍니다.
+
+<br>
+
+## 9. 마무리하기 - 터치이벤트
+
+### 추가내용
+
+##### 1. 파이그래프에 터치이벤트 추가
+
+`PieGraphView` 에 아래 요구사항의 터치이벤트를 구현했습니다.
+
+- 그래프를 터치하면 검정색 동그라미 그래프가 그려지도록.
+- 그래프를 터치한 상태로 손가락을 움직일 때, 그 방향으로 그래프 사이즈가 재조정되도록.
+- 그래프에서 손가락을 떼면, 현재 사이즈로 그래프 색상이 바뀌어서 구매이력 그래프가 다시 그려지도록.
+- 그래프 사이즈가 제한한 최대/최소 범위를 벗어나지않도록
+
+```swift
+class PieGraphView: UIView {
+    private var touched: Bool = false
+    ...
+    override func draw(_ rect: CGRect) {
+        super.draw(rect)
+        if touched {
+            drawDefaultCircle()
+        } else {
+            drawPieGraph()
+        }
+    }
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) { ... }
+    override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) { ... }
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) { ... }
+    override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) { ... }
+    ...
+}
+```
+
+`PieGraphView` 에 터치 이벤트 메소드를 오버라이드하고, 각각의 동작 이후 **draw(rect:)** 메소드를 직접 호출하지 않고  **setNeedsDisplay()** 메소드를 호출해주었습니다. 
+
+`draw(rect:)` 메소드는 절대 직접 호출하여 사용하지 않고, [setNeedsDisplay()](https://developer.apple.com/documentation/uikit/uiview/1622437-setneedsdisplay) 메소드를 통해 호출되도록 구현해야합니다. [Swift docs 참고](https://developer.apple.com/documentation/uikit/uiview/1622529-draw)
+
+<br>
+
+##### 2. shake 모션 이벤트 추가
+
+- shake 모션이 일어나면, 기존 그래프의 사이즈로 복구하도록.
+
+해당 요구사항은 `AdminViewController` 에서 아래의 메소드를 오버라이드하여 구현했습니다.
+
+```swift
+override func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
+    super.motionEnded(motion, with: event)
+    if motion == .motionShake {
+        ...
+    }
+}
+```
+
+<br>
+
+### 실행화면
+
+> 완성일자: 2019.01.22 17:24
+
+![Jan-22-2019](./images/step9/Jan-22-2019.gif)
+

--- a/VendingMachineApp/VendingMachineApp.xcodeproj/xcshareddata/xcschemes/VendingMachineApp.xcscheme
+++ b/VendingMachineApp/VendingMachineApp.xcodeproj/xcshareddata/xcschemes/VendingMachineApp.xcscheme
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A3E1B2E521CFE07900B35A96"
+               BuildableName = "VendingMachineApp.app"
+               BlueprintName = "VendingMachineApp"
+               ReferencedContainer = "container:VendingMachineApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A3E1B2F921CFE07C00B35A96"
+               BuildableName = "VendingMachineAppTests.xctest"
+               BlueprintName = "VendingMachineAppTests"
+               ReferencedContainer = "container:VendingMachineApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A3E1B30421CFE07C00B35A96"
+               BuildableName = "VendingMachineAppUITests.xctest"
+               BlueprintName = "VendingMachineAppUITests"
+               ReferencedContainer = "container:VendingMachineApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A3E1B2E521CFE07900B35A96"
+            BuildableName = "VendingMachineApp.app"
+            BlueprintName = "VendingMachineApp"
+            ReferencedContainer = "container:VendingMachineApp.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A3E1B2E521CFE07900B35A96"
+            BuildableName = "VendingMachineApp.app"
+            BlueprintName = "VendingMachineApp"
+            ReferencedContainer = "container:VendingMachineApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A3E1B2E521CFE07900B35A96"
+            BuildableName = "VendingMachineApp.app"
+            BlueprintName = "VendingMachineApp"
+            ReferencedContainer = "container:VendingMachineApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/VendingMachineApp/VendingMachineApp/AdminViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/AdminViewController.swift
@@ -86,4 +86,11 @@ extension AdminViewController: HistoryDataSource {
         return purchases.reduce(into: [:]) { $0[$1.title, default: 0] += 1 }
     }
 
+    override func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
+        super.motionEnded(motion, with: event)
+        if motion == .motionShake {
+            purchasePieGraph.setDefaultRadius()
+        }
+    }
+
 }

--- a/VendingMachineApp/VendingMachineApp/CustomView/PieGraphView.swift
+++ b/VendingMachineApp/VendingMachineApp/CustomView/PieGraphView.swift
@@ -17,13 +17,9 @@ class PieGraphView: UIView {
                                       UIColor(red:0.63, green:0.78, blue:0.75, alpha:1.0)]
     var historyDataSource: HistoryDataSource?
     private var touched: Bool = false
-
+    private var radiusOfPie: CGFloat = 200
     private var centerOfPie: CGPoint {
         return CGPoint(x: bounds.midX, y: bounds.midY)
-    }
-
-    private var radiusOfPie: CGFloat {
-        return bounds.width.half
     }
 
     private func drawAPieceOfPie(startAngle: CGFloat, endAngle: CGFloat) {
@@ -51,8 +47,9 @@ class PieGraphView: UIView {
         guard let classifiedPurchase = historyDataSource?.classifiedPurchase else { return }
         let total = classifiedPurchase.values.reduce(0) { $0 + $1 }
         var currentAngle: CGFloat = 0
+        let randomPalette = palette.shuffled()
         for (index, purchase) in classifiedPurchase.enumerated() {
-            palette[index].setFill()
+            randomPalette[index].setFill()
             let angle = purchase.value.convertedToAnglesInCircle(total: total)
             let endAngle = currentAngle + angle
             drawAPieceOfPie(startAngle: currentAngle, endAngle: endAngle)
@@ -81,8 +78,30 @@ class PieGraphView: UIView {
         setNeedsDisplay()
     }
 
+    private func resizeRadius(by point: CGPoint) -> Bool {
+        let distance = point.distance(from: centerOfPie)
+        if 50 < distance && distance < 200 {
+            radiusOfPie = distance
+            return true
+        }
+        return false
+    }
+
+    override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesMoved(touches, with: event)
+        guard let point = touches.first?.location(in: self) else { return }
+        guard resizeRadius(by: point) else { return }
+        setNeedsDisplay()
+    }
+
     override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
         super.touchesEnded(touches, with: event)
+        touched = false
+        setNeedsDisplay()
+    }
+
+    override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesCancelled(touches, with: event)
         touched = false
         setNeedsDisplay()
     }
@@ -101,6 +120,14 @@ extension CGFloat {
 
     var half: CGFloat {
         return self * 0.5
+    }
+
+}
+
+extension CGPoint {
+
+    func distance(from point: CGPoint) -> CGFloat {
+        return sqrt(pow((self.x - point.x), 2) + pow((self.y - point.y), 2))
     }
 
 }

--- a/VendingMachineApp/VendingMachineApp/CustomView/PieGraphView.swift
+++ b/VendingMachineApp/VendingMachineApp/CustomView/PieGraphView.swift
@@ -16,6 +16,7 @@ class PieGraphView: UIView {
                                       UIColor(red:0.31, green:0.78, blue:0.80, alpha:1.0),
                                       UIColor(red:0.63, green:0.78, blue:0.75, alpha:1.0)]
     var historyDataSource: HistoryDataSource?
+    private var touched: Bool = false
 
     private var centerOfPie: CGPoint {
         return CGPoint(x: bounds.midX, y: bounds.midY)
@@ -46,8 +47,7 @@ class PieGraphView: UIView {
                                               NSAttributedString.Key.foregroundColor: UIColor.white])
     }
 
-    override func draw(_ rect: CGRect) {
-        super.draw(rect)
+    private func drawPieGraph() {
         guard let classifiedPurchase = historyDataSource?.classifiedPurchase else { return }
         let total = classifiedPurchase.values.reduce(0) { $0 + $1 }
         var currentAngle: CGFloat = 0
@@ -59,6 +59,32 @@ class PieGraphView: UIView {
             drawLabel(text: purchase.key as NSString, startAngle: currentAngle, endAngle: endAngle)
             currentAngle = endAngle
         }
+    }
+
+    private func drawDefaultCircle() {
+        UIColor.black.setFill()
+        drawAPieceOfPie(startAngle: 0, endAngle: .pi*2)
+    }
+
+    override func draw(_ rect: CGRect) {
+        super.draw(rect)
+        if touched {
+            drawDefaultCircle()
+        } else {
+            drawPieGraph()
+        }
+    }
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesBegan(touches, with: event)
+        touched = true
+        setNeedsDisplay()
+    }
+
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesEnded(touches, with: event)
+        touched = false
+        setNeedsDisplay()
     }
 
 }

--- a/VendingMachineApp/VendingMachineApp/CustomView/PieGraphView.swift
+++ b/VendingMachineApp/VendingMachineApp/CustomView/PieGraphView.swift
@@ -22,6 +22,11 @@ class PieGraphView: UIView {
         return CGPoint(x: bounds.midX, y: bounds.midY)
     }
 
+    func setDefaultRadius() {
+        radiusOfPie = 200
+        setNeedsDisplay()
+    }
+
     private func drawAPieceOfPie(startAngle: CGFloat, endAngle: CGFloat) {
         let path = UIBezierPath(arcCenter: centerOfPie,
                                 radius: radiusOfPie,


### PR DESCRIPTION
- `PieGraphView` 에 터치이벤트 핸들러를 추가해 아래 요구사항을 구현했습니다.
   - 그래프를 터치하면 검정색 동그라미 그래프가 그려지도록.
   - 그래프를 터치한 상태로 손가락을 움직일 때, 그 방향으로 그래프 사이즈가 재조정되도록.
   - 그래프에서 손가락을 떼면, 현재 사이즈로 그래프 색상이 바뀌어서 구매이력 그래프가 다시 그려지도록.
   - 그래프 사이즈가 제한한 최대/최소 범위를 벗어나지않도록.
   - shake 모션이 일어나면, 기존 그래프의 사이즈로 복구하도록.
- 추가 내용과 실행화면 이미지를 README에 정리했습니다.