### PR TITLE
[step6] 구매목록 view에 반영 

### DIFF
--- a/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
+++ b/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		30609E1B2407F71000EF3645 /* Soda.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30609E1A2407F71000EF3645 /* Soda.swift */; };
 		30609E1D2407F72A00EF3645 /* Coffee.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30609E1C2407F72A00EF3645 /* Coffee.swift */; };
 		30A96ACE241E1BBA00847588 /* PurchaseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30A96ACD241E1BBA00847588 /* PurchaseButton.swift */; };
+		30A96AD0241E325100847588 /* AddStockButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30A96ACF241E325100847588 /* AddStockButton.swift */; };
+		30A96AD2241E357900847588 /* StockCountLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30A96AD1241E357900847588 /* StockCountLabel.swift */; };
 		30B6CA44241297BB00C7FA28 /* ExtendedDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30B6CA43241297BB00C7FA28 /* ExtendedDate.swift */; };
 		30B9CB71240FEF8B002760FE /* BananaMilk.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30B9CB70240FEF8B002760FE /* BananaMilk.swift */; };
 		30B9CB73240FF21B002760FE /* ChocoMilk.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30B9CB72240FF21B002760FE /* ChocoMilk.swift */; };
@@ -63,6 +65,8 @@
 		30609E1A2407F71000EF3645 /* Soda.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Soda.swift; sourceTree = "<group>"; };
 		30609E1C2407F72A00EF3645 /* Coffee.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coffee.swift; sourceTree = "<group>"; };
 		30A96ACD241E1BBA00847588 /* PurchaseButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseButton.swift; sourceTree = "<group>"; };
+		30A96ACF241E325100847588 /* AddStockButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddStockButton.swift; sourceTree = "<group>"; };
+		30A96AD1241E357900847588 /* StockCountLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockCountLabel.swift; sourceTree = "<group>"; };
 		30B6CA43241297BB00C7FA28 /* ExtendedDate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtendedDate.swift; sourceTree = "<group>"; };
 		30B9CB70240FEF8B002760FE /* BananaMilk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BananaMilk.swift; sourceTree = "<group>"; };
 		30B9CB72240FF21B002760FE /* ChocoMilk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChocoMilk.swift; sourceTree = "<group>"; };
@@ -162,6 +166,8 @@
 			isa = PBXGroup;
 			children = (
 				30A96ACD241E1BBA00847588 /* PurchaseButton.swift */,
+				30A96ACF241E325100847588 /* AddStockButton.swift */,
+				30A96AD1241E357900847588 /* StockCountLabel.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -313,8 +319,10 @@
 			files = (
 				30F1CC602413CEB6000609F5 /* Milkis.swift in Sources */,
 				30B9CB77240FF28D002760FE /* Coke.swift in Sources */,
+				30A96AD0241E325100847588 /* AddStockButton.swift in Sources */,
 				300CD768240EA35100085882 /* Beverages.swift in Sources */,
 				30B9CB7D240FF3ED002760FE /* Mocha.swift in Sources */,
+				30A96AD2241E357900847588 /* StockCountLabel.swift in Sources */,
 				30B9CB75240FF256002760FE /* StrawberryMilk.swift in Sources */,
 				30B9CB71240FEF8B002760FE /* BananaMilk.swift in Sources */,
 				30609E1B2407F71000EF3645 /* Soda.swift in Sources */,

--- a/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
+++ b/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		30609E192407F6EE00EF3645 /* Milk.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30609E182407F6EE00EF3645 /* Milk.swift */; };
 		30609E1B2407F71000EF3645 /* Soda.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30609E1A2407F71000EF3645 /* Soda.swift */; };
 		30609E1D2407F72A00EF3645 /* Coffee.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30609E1C2407F72A00EF3645 /* Coffee.swift */; };
+		30A96ACE241E1BBA00847588 /* PurchaseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30A96ACD241E1BBA00847588 /* PurchaseButton.swift */; };
 		30B6CA44241297BB00C7FA28 /* ExtendedDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30B6CA43241297BB00C7FA28 /* ExtendedDate.swift */; };
 		30B9CB71240FEF8B002760FE /* BananaMilk.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30B9CB70240FEF8B002760FE /* BananaMilk.swift */; };
 		30B9CB73240FF21B002760FE /* ChocoMilk.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30B9CB72240FF21B002760FE /* ChocoMilk.swift */; };
@@ -61,6 +62,7 @@
 		30609E182407F6EE00EF3645 /* Milk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Milk.swift; sourceTree = "<group>"; };
 		30609E1A2407F71000EF3645 /* Soda.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Soda.swift; sourceTree = "<group>"; };
 		30609E1C2407F72A00EF3645 /* Coffee.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coffee.swift; sourceTree = "<group>"; };
+		30A96ACD241E1BBA00847588 /* PurchaseButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseButton.swift; sourceTree = "<group>"; };
 		30B6CA43241297BB00C7FA28 /* ExtendedDate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtendedDate.swift; sourceTree = "<group>"; };
 		30B9CB70240FEF8B002760FE /* BananaMilk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BananaMilk.swift; sourceTree = "<group>"; };
 		30B9CB72240FF21B002760FE /* ChocoMilk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChocoMilk.swift; sourceTree = "<group>"; };
@@ -132,6 +134,7 @@
 		30609E002407EFC100EF3645 /* VendingMachineApp */ = {
 			isa = PBXGroup;
 			children = (
+				30A96ACC241E1BA300847588 /* View */,
 				30609E152407F3F800EF3645 /* Model */,
 				30609E012407EFC100EF3645 /* AppDelegate.swift */,
 				30609E032407EFC100EF3645 /* SceneDelegate.swift */,
@@ -153,6 +156,14 @@
 				30EDDE7E241A118B0066AAAE /* VendingMachineManager.swift */,
 			);
 			path = Model;
+			sourceTree = "<group>";
+		};
+		30A96ACC241E1BA300847588 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				30A96ACD241E1BBA00847588 /* PurchaseButton.swift */,
+			);
+			path = View;
 			sourceTree = "<group>";
 		};
 		30FC1B6A2410E8DA000DFF44 /* Milk */ = {
@@ -310,6 +321,7 @@
 				30609E062407EFC100EF3645 /* ViewController.swift in Sources */,
 				30B9CB7F240FF416002760FE /* Latte.swift in Sources */,
 				30B6CA44241297BB00C7FA28 /* ExtendedDate.swift in Sources */,
+				30A96ACE241E1BBA00847588 /* PurchaseButton.swift in Sources */,
 				30B9CB73240FF21B002760FE /* ChocoMilk.swift in Sources */,
 				30EDDE7F241A118C0066AAAE /* VendingMachineManager.swift in Sources */,
 				30609E022407EFC100EF3645 /* AppDelegate.swift in Sources */,

--- a/VendingMachineApp/VendingMachineApp/Base.lproj/Main.storyboard
+++ b/VendingMachineApp/VendingMachineApp/Base.lproj/Main.storyboard
@@ -23,7 +23,7 @@
                                         <rect key="frame" x="28" y="120" width="833" height="198"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xW5-h4-OFc">
+                                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xW5-h4-OFc" customClass="AddStockButton" customModule="VendingMachineApp" customModuleProvider="target">
                                                 <rect key="frame" x="68" y="8" width="62" height="22"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <state key="normal" title="재고 추가"/>
@@ -35,14 +35,14 @@
                                                 <rect key="frame" x="55" y="33" width="90" height="110"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hyx-pa-PbC">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hyx-pa-PbC" customClass="StockCountLabel" customModule="VendingMachineApp" customModuleProvider="target">
                                                 <rect key="frame" x="93" y="145" width="12" height="22"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="18"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <button opaque="NO" tag="1" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ajS-vh-lX2">
+                                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ajS-vh-lX2" customClass="AddStockButton" customModule="VendingMachineApp" customModuleProvider="target">
                                                 <rect key="frame" x="218" y="8" width="62" height="22"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <state key="normal" title="재고 추가"/>
@@ -54,14 +54,14 @@
                                                 <rect key="frame" x="202" y="33" width="90" height="110"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" tag="1" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="T4C-eG-bqi">
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="1" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="T4C-eG-bqi" customClass="StockCountLabel" customModule="VendingMachineApp" customModuleProvider="target">
                                                 <rect key="frame" x="241" y="143" width="12" height="22"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="18"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <button opaque="NO" tag="2" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lHY-v2-mlJ">
+                                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lHY-v2-mlJ" customClass="AddStockButton" customModule="VendingMachineApp" customModuleProvider="target">
                                                 <rect key="frame" x="369" y="8" width="62" height="22"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <state key="normal" title="재고 추가"/>
@@ -73,14 +73,14 @@
                                                 <rect key="frame" x="355" y="33" width="90" height="110"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" tag="2" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6hc-0j-uDF">
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="2" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6hc-0j-uDF" customClass="StockCountLabel" customModule="VendingMachineApp" customModuleProvider="target">
                                                 <rect key="frame" x="395" y="145" width="12" height="22"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="18"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <button opaque="NO" tag="3" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3cf-Ao-Mgn">
+                                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3cf-Ao-Mgn" customClass="AddStockButton" customModule="VendingMachineApp" customModuleProvider="target">
                                                 <rect key="frame" x="526" y="8" width="62" height="22"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <state key="normal" title="재고 추가"/>
@@ -92,14 +92,14 @@
                                                 <rect key="frame" x="512" y="33" width="90" height="110"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" tag="3" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VQ1-pp-ryN">
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="3" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VQ1-pp-ryN" customClass="StockCountLabel" customModule="VendingMachineApp" customModuleProvider="target">
                                                 <rect key="frame" x="552" y="145" width="12" height="22"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="18"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <button opaque="NO" tag="4" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HTa-vg-J6C">
+                                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HTa-vg-J6C" customClass="AddStockButton" customModule="VendingMachineApp" customModuleProvider="target">
                                                 <rect key="frame" x="696" y="8" width="62" height="22"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <state key="normal" title="재고 추가"/>
@@ -111,14 +111,14 @@
                                                 <rect key="frame" x="677" y="33" width="90" height="110"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" tag="4" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Onb-0R-oTr">
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="4" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Onb-0R-oTr" customClass="StockCountLabel" customModule="VendingMachineApp" customModuleProvider="target">
                                                 <rect key="frame" x="717" y="145" width="12" height="22"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="18"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <button opaque="NO" tag="1" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zI0-Qy-hgk" customClass="PurchaseButton" customModule="VendingMachineApp" customModuleProvider="target">
+                                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zI0-Qy-hgk" customClass="PurchaseButton" customModule="VendingMachineApp" customModuleProvider="target">
                                                 <rect key="frame" x="232" y="167" width="30" height="20"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
@@ -129,7 +129,7 @@
                                                     <action selector="purchaseBeverageWithButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="rfo-GU-Eso"/>
                                                 </connections>
                                             </button>
-                                            <button opaque="NO" tag="2" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="14X-Gx-cnX" customClass="PurchaseButton" customModule="VendingMachineApp" customModuleProvider="target">
+                                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="14X-Gx-cnX" customClass="PurchaseButton" customModule="VendingMachineApp" customModuleProvider="target">
                                                 <rect key="frame" x="385" y="167" width="30" height="20"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
@@ -140,7 +140,7 @@
                                                     <action selector="purchaseBeverageWithButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="cv7-zQ-lQh"/>
                                                 </connections>
                                             </button>
-                                            <button opaque="NO" tag="3" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eJO-e2-m0c" customClass="PurchaseButton" customModule="VendingMachineApp" customModuleProvider="target">
+                                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eJO-e2-m0c" customClass="PurchaseButton" customModule="VendingMachineApp" customModuleProvider="target">
                                                 <rect key="frame" x="542" y="167" width="30" height="20"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
@@ -151,7 +151,7 @@
                                                     <action selector="purchaseBeverageWithButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="nB5-3C-WbF"/>
                                                 </connections>
                                             </button>
-                                            <button opaque="NO" tag="4" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="of3-Fp-b9E" customClass="PurchaseButton" customModule="VendingMachineApp" customModuleProvider="target">
+                                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="of3-Fp-b9E" customClass="PurchaseButton" customModule="VendingMachineApp" customModuleProvider="target">
                                                 <rect key="frame" x="707" y="167" width="30" height="20"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
@@ -256,7 +256,7 @@
                                         <rect key="frame" x="28" y="342" width="833" height="198"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <subviews>
-                                            <button opaque="NO" tag="5" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="guR-mL-7Ak">
+                                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="guR-mL-7Ak" customClass="AddStockButton" customModule="VendingMachineApp" customModuleProvider="target">
                                                 <rect key="frame" x="68" y="8" width="62" height="22"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <state key="normal" title="재고 추가"/>
@@ -268,14 +268,14 @@
                                                 <rect key="frame" x="54" y="33" width="90" height="110"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" tag="5" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ksl-fX-j4V">
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="5" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ksl-fX-j4V" customClass="StockCountLabel" customModule="VendingMachineApp" customModuleProvider="target">
                                                 <rect key="frame" x="94" y="147" width="12" height="22"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="18"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <button opaque="NO" tag="6" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jwJ-Ax-fen">
+                                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jwJ-Ax-fen" customClass="AddStockButton" customModule="VendingMachineApp" customModuleProvider="target">
                                                 <rect key="frame" x="223" y="8" width="62" height="22"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <state key="normal" title="재고 추가"/>
@@ -287,14 +287,14 @@
                                                 <rect key="frame" x="209" y="33" width="90" height="110"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" tag="6" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Aic-Kx-6bX">
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="6" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Aic-Kx-6bX" customClass="StockCountLabel" customModule="VendingMachineApp" customModuleProvider="target">
                                                 <rect key="frame" x="249" y="147" width="12" height="22"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="18"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <button opaque="NO" tag="7" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BQc-j5-MAz">
+                                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BQc-j5-MAz" customClass="AddStockButton" customModule="VendingMachineApp" customModuleProvider="target">
                                                 <rect key="frame" x="369" y="8" width="62" height="22"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <state key="normal" title="재고 추가"/>
@@ -306,14 +306,14 @@
                                                 <rect key="frame" x="355" y="33" width="90" height="110"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" tag="7" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="M8P-FB-WSY">
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="7" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="M8P-FB-WSY" customClass="StockCountLabel" customModule="VendingMachineApp" customModuleProvider="target">
                                                 <rect key="frame" x="395" y="147" width="12" height="22"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="18"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <button opaque="NO" tag="8" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aHJ-Zh-p0Q">
+                                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aHJ-Zh-p0Q" customClass="AddStockButton" customModule="VendingMachineApp" customModuleProvider="target">
                                                 <rect key="frame" x="531" y="8" width="62" height="22"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <state key="normal" title="재고 추가"/>
@@ -325,14 +325,14 @@
                                                 <rect key="frame" x="515" y="33" width="90" height="110"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" tag="8" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YAU-Sv-cdf">
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="8" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YAU-Sv-cdf" customClass="StockCountLabel" customModule="VendingMachineApp" customModuleProvider="target">
                                                 <rect key="frame" x="555" y="147" width="12" height="22"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="18"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <button opaque="NO" tag="5" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UwJ-ld-QnP" customClass="PurchaseButton" customModule="VendingMachineApp" customModuleProvider="target">
+                                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UwJ-ld-QnP" customClass="PurchaseButton" customModule="VendingMachineApp" customModuleProvider="target">
                                                 <rect key="frame" x="84" y="168" width="30" height="20"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
@@ -343,7 +343,7 @@
                                                     <action selector="purchaseBeverageWithButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ddc-9s-xTj"/>
                                                 </connections>
                                             </button>
-                                            <button opaque="NO" tag="7" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JyH-MH-Uhn" customClass="PurchaseButton" customModule="VendingMachineApp" customModuleProvider="target">
+                                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JyH-MH-Uhn" customClass="PurchaseButton" customModule="VendingMachineApp" customModuleProvider="target">
                                                 <rect key="frame" x="385" y="168" width="30" height="20"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
@@ -354,7 +354,7 @@
                                                     <action selector="purchaseBeverageWithButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="RVn-Z2-jnU"/>
                                                 </connections>
                                             </button>
-                                            <button opaque="NO" tag="8" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EvN-A1-MM4" customClass="PurchaseButton" customModule="VendingMachineApp" customModuleProvider="target">
+                                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EvN-A1-MM4" customClass="PurchaseButton" customModule="VendingMachineApp" customModuleProvider="target">
                                                 <rect key="frame" x="545" y="168" width="30" height="20"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
@@ -365,7 +365,7 @@
                                                     <action selector="purchaseBeverageWithButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="8P9-2T-NtA"/>
                                                 </connections>
                                             </button>
-                                            <button opaque="NO" tag="6" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="muD-o0-hTH" customClass="PurchaseButton" customModule="VendingMachineApp" customModuleProvider="target">
+                                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="muD-o0-hTH" customClass="PurchaseButton" customModule="VendingMachineApp" customModuleProvider="target">
                                                 <rect key="frame" x="239" y="169" width="30" height="20"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>

--- a/VendingMachineApp/VendingMachineApp/Base.lproj/Main.storyboard
+++ b/VendingMachineApp/VendingMachineApp/Base.lproj/Main.storyboard
@@ -20,7 +20,7 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xGL-Fs-eef">
-                                        <rect key="frame" x="28" y="127" width="833" height="198"/>
+                                        <rect key="frame" x="28" y="120" width="833" height="198"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xW5-h4-OFc">
@@ -118,11 +118,66 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
+                                            <button opaque="NO" tag="1" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zI0-Qy-hgk">
+                                                <rect key="frame" x="232" y="167" width="30" height="20"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
+                                                <state key="normal" title="구매">
+                                                    <color key="titleColor" red="0.80044416240000005" green="0.2472920435" blue="0.20724295240000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </state>
+                                                <connections>
+                                                    <action selector="purchaseBeverageWithButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="rfo-GU-Eso"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" tag="2" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="14X-Gx-cnX">
+                                                <rect key="frame" x="385" y="167" width="30" height="20"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
+                                                <state key="normal" title="구매">
+                                                    <color key="titleColor" red="0.80044416240000005" green="0.2472920435" blue="0.20724295240000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </state>
+                                                <connections>
+                                                    <action selector="purchaseBeverageWithButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="cv7-zQ-lQh"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" tag="3" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eJO-e2-m0c">
+                                                <rect key="frame" x="542" y="167" width="30" height="20"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
+                                                <state key="normal" title="구매">
+                                                    <color key="titleColor" red="0.80044416240000005" green="0.2472920435" blue="0.20724295240000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </state>
+                                                <connections>
+                                                    <action selector="purchaseBeverageWithButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="nB5-3C-WbF"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" tag="4" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="of3-Fp-b9E">
+                                                <rect key="frame" x="707" y="167" width="30" height="20"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
+                                                <state key="normal" title="구매">
+                                                    <color key="titleColor" red="0.80044416240000005" green="0.2472920435" blue="0.20724295240000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </state>
+                                                <connections>
+                                                    <action selector="purchaseBeverageWithButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="0k5-2g-nGM"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6SB-7n-J2t">
+                                                <rect key="frame" x="84" y="167" width="30" height="20"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
+                                                <state key="normal" title="구매">
+                                                    <color key="titleColor" red="0.80044416240000005" green="0.2472920435" blue="0.20724295240000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </state>
+                                                <connections>
+                                                    <action selector="purchaseBeverageWithButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ArD-8T-NuO"/>
+                                                </connections>
+                                            </button>
                                         </subviews>
                                         <color key="backgroundColor" red="0.75080337749631343" green="0.9066751339280007" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </view>
                                     <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="e2F-8d-h01">
-                                        <rect key="frame" x="894" y="127" width="261" height="379"/>
+                                        <rect key="frame" x="894" y="120" width="261" height="379"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="잔액" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0mo-Sk-2a0">
@@ -198,7 +253,7 @@
                                         <color key="backgroundColor" red="0.94182265228426398" green="0.94182265228426398" blue="0.94182265228426398" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </view>
                                     <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="G3r-Om-M6D">
-                                        <rect key="frame" x="28" y="349" width="833" height="198"/>
+                                        <rect key="frame" x="28" y="342" width="833" height="198"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <subviews>
                                             <button opaque="NO" tag="5" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="guR-mL-7Ak">
@@ -214,7 +269,7 @@
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" tag="5" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ksl-fX-j4V">
-                                                <rect key="frame" x="94" y="151" width="12" height="22"/>
+                                                <rect key="frame" x="94" y="147" width="12" height="22"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="18"/>
                                                 <nil key="textColor"/>
@@ -233,7 +288,7 @@
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" tag="6" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Aic-Kx-6bX">
-                                                <rect key="frame" x="249" y="151" width="12" height="22"/>
+                                                <rect key="frame" x="249" y="147" width="12" height="22"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="18"/>
                                                 <nil key="textColor"/>
@@ -252,7 +307,7 @@
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" tag="7" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="M8P-FB-WSY">
-                                                <rect key="frame" x="395" y="148" width="12" height="22"/>
+                                                <rect key="frame" x="395" y="147" width="12" height="22"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="18"/>
                                                 <nil key="textColor"/>
@@ -271,12 +326,56 @@
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" tag="8" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YAU-Sv-cdf">
-                                                <rect key="frame" x="555" y="150" width="12" height="22"/>
+                                                <rect key="frame" x="555" y="147" width="12" height="22"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="18"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
+                                            <button opaque="NO" tag="5" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UwJ-ld-QnP">
+                                                <rect key="frame" x="84" y="168" width="30" height="20"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
+                                                <state key="normal" title="구매">
+                                                    <color key="titleColor" red="0.80044416240000005" green="0.2472920435" blue="0.20724295240000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </state>
+                                                <connections>
+                                                    <action selector="purchaseBeverageWithButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ddc-9s-xTj"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" tag="7" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JyH-MH-Uhn">
+                                                <rect key="frame" x="385" y="168" width="30" height="20"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
+                                                <state key="normal" title="구매">
+                                                    <color key="titleColor" red="0.80044416240000005" green="0.2472920435" blue="0.20724295240000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </state>
+                                                <connections>
+                                                    <action selector="purchaseBeverageWithButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="RVn-Z2-jnU"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" tag="8" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EvN-A1-MM4">
+                                                <rect key="frame" x="545" y="168" width="30" height="20"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
+                                                <state key="normal" title="구매">
+                                                    <color key="titleColor" red="0.80044416240000005" green="0.2472920435" blue="0.20724295240000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </state>
+                                                <connections>
+                                                    <action selector="purchaseBeverageWithButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="8P9-2T-NtA"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" tag="6" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="muD-o0-hTH">
+                                                <rect key="frame" x="239" y="169" width="30" height="20"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
+                                                <state key="normal" title="구매">
+                                                    <color key="titleColor" red="0.80044416240000005" green="0.2472920435" blue="0.20724295240000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </state>
+                                                <connections>
+                                                    <action selector="purchaseBeverageWithButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="b4N-33-QaU"/>
+                                                </connections>
+                                            </button>
                                         </subviews>
                                         <color key="backgroundColor" red="0.75080337750000004" green="0.90667513389999999" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </view>
@@ -285,6 +384,18 @@
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <fontDescription key="fontDescription" name="HelveticaNeue-BoldItalic" family="Helvetica Neue" pointSize="45"/>
                                         <color key="textColor" red="0.86488737305989849" green="0.19882639494112836" blue="0.11271484365905103" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qTY-FW-4R1">
+                                        <rect key="frame" x="28" y="612" width="833" height="174"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <color key="backgroundColor" red="0.75080337750000004" green="0.90667513389999999" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    </view>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Purchased Lists" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7dE-5D-OEQ">
+                                        <rect key="frame" x="28" y="574" width="191" height="30"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <fontDescription key="fontDescription" name="HelveticaNeue-BoldItalic" family="Helvetica Neue" pointSize="25"/>
+                                        <color key="textColor" red="0.86488737309999997" green="0.19882639490000001" blue="0.1127148437" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
@@ -314,15 +425,15 @@
                         <outletCollection property="stockCountLabels" destination="Aic-Kx-6bX" collectionClass="NSMutableArray" id="56f-kk-BzO"/>
                         <outletCollection property="stockCountLabels" destination="M8P-FB-WSY" collectionClass="NSMutableArray" id="du5-Yu-dyJ"/>
                         <outletCollection property="stockCountLabels" destination="YAU-Sv-cdf" collectionClass="NSMutableArray" id="ngm-ef-gL7"/>
-                        <outletCollection property="beverageImages" destination="8dW-n1-pYK" collectionClass="NSMutableArray" id="Tl0-AE-FQ2"/>
-                        <outletCollection property="beverageImages" destination="O98-m8-4ev" collectionClass="NSMutableArray" id="fDs-i4-itX"/>
-                        <outletCollection property="beverageImages" destination="PZz-A6-HTJ" collectionClass="NSMutableArray" id="6xm-cH-MTh"/>
-                        <outletCollection property="beverageImages" destination="Uwp-8D-7Ae" collectionClass="NSMutableArray" id="eU1-U4-V3X"/>
-                        <outletCollection property="beverageImages" destination="gwc-Oe-r2q" collectionClass="NSMutableArray" id="eL9-Zf-y7B"/>
-                        <outletCollection property="beverageImages" destination="amr-hq-Llx" collectionClass="NSMutableArray" id="Nvx-OS-Blw"/>
-                        <outletCollection property="beverageImages" destination="N8r-qo-N5B" collectionClass="NSMutableArray" id="6Ou-9p-vDN"/>
-                        <outletCollection property="beverageImages" destination="Uim-wa-5D7" collectionClass="NSMutableArray" id="Qrh-cR-4W0"/>
-                        <outletCollection property="beverageImages" destination="mw7-1B-AUc" collectionClass="NSMutableArray" id="Hfr-gN-EiZ"/>
+                        <outletCollection property="beverageImageViews" destination="8dW-n1-pYK" collectionClass="NSMutableArray" id="Tl0-AE-FQ2"/>
+                        <outletCollection property="beverageImageViews" destination="O98-m8-4ev" collectionClass="NSMutableArray" id="fDs-i4-itX"/>
+                        <outletCollection property="beverageImageViews" destination="PZz-A6-HTJ" collectionClass="NSMutableArray" id="6xm-cH-MTh"/>
+                        <outletCollection property="beverageImageViews" destination="Uwp-8D-7Ae" collectionClass="NSMutableArray" id="eU1-U4-V3X"/>
+                        <outletCollection property="beverageImageViews" destination="gwc-Oe-r2q" collectionClass="NSMutableArray" id="eL9-Zf-y7B"/>
+                        <outletCollection property="beverageImageViews" destination="amr-hq-Llx" collectionClass="NSMutableArray" id="Nvx-OS-Blw"/>
+                        <outletCollection property="beverageImageViews" destination="N8r-qo-N5B" collectionClass="NSMutableArray" id="6Ou-9p-vDN"/>
+                        <outletCollection property="beverageImageViews" destination="Uim-wa-5D7" collectionClass="NSMutableArray" id="Qrh-cR-4W0"/>
+                        <outletCollection property="beverageImageViews" destination="mw7-1B-AUc" collectionClass="NSMutableArray" id="Hfr-gN-EiZ"/>
                         <outletCollection property="backgroundViews" destination="xGL-Fs-eef" collectionClass="NSMutableArray" id="kRZ-kp-xCz"/>
                         <outletCollection property="backgroundViews" destination="G3r-Om-M6D" collectionClass="NSMutableArray" id="NTg-Vc-vIj"/>
                         <outletCollection property="backgroundViews" destination="e2F-8d-h01" collectionClass="NSMutableArray" id="OXC-YK-Ex8"/>
@@ -330,6 +441,16 @@
                         <outletCollection property="addMoneyButtons" destination="nNo-Jf-NSo" collectionClass="NSMutableArray" id="Lnh-CT-d3c"/>
                         <outletCollection property="addMoneyButtons" destination="Xpl-Gr-jHE" collectionClass="NSMutableArray" id="kLB-1y-2hO"/>
                         <outletCollection property="addMoneyButtons" destination="kkk-aF-JPS" collectionClass="NSMutableArray" id="CzN-tg-i26"/>
+                        <outletCollection property="purchaseButtons" destination="6SB-7n-J2t" collectionClass="NSMutableArray" id="VJ0-Id-waO"/>
+                        <outletCollection property="purchaseButtons" destination="zI0-Qy-hgk" collectionClass="NSMutableArray" id="HBS-Dq-Uk1"/>
+                        <outletCollection property="purchaseButtons" destination="14X-Gx-cnX" collectionClass="NSMutableArray" id="qH5-Lj-7Wk"/>
+                        <outletCollection property="purchaseButtons" destination="eJO-e2-m0c" collectionClass="NSMutableArray" id="pX1-7X-hg8"/>
+                        <outletCollection property="purchaseButtons" destination="of3-Fp-b9E" collectionClass="NSMutableArray" id="6xd-uQ-Ml2"/>
+                        <outletCollection property="purchaseButtons" destination="UwJ-ld-QnP" collectionClass="NSMutableArray" id="QVm-q0-McD"/>
+                        <outletCollection property="purchaseButtons" destination="muD-o0-hTH" collectionClass="NSMutableArray" id="XIA-X2-FNx"/>
+                        <outletCollection property="purchaseButtons" destination="JyH-MH-Uhn" collectionClass="NSMutableArray" id="Cpn-Z4-HkT"/>
+                        <outletCollection property="purchaseButtons" destination="EvN-A1-MM4" collectionClass="NSMutableArray" id="KFm-fp-p4E"/>
+                        <outletCollection property="backgroundViews" destination="qTY-FW-4R1" collectionClass="NSMutableArray" id="SA2-0E-tR4"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/VendingMachineApp/VendingMachineApp/Base.lproj/Main.storyboard
+++ b/VendingMachineApp/VendingMachineApp/Base.lproj/Main.storyboard
@@ -118,7 +118,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <button opaque="NO" tag="1" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zI0-Qy-hgk">
+                                            <button opaque="NO" tag="1" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zI0-Qy-hgk" customClass="PurchaseButton" customModule="VendingMachineApp" customModuleProvider="target">
                                                 <rect key="frame" x="232" y="167" width="30" height="20"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
@@ -129,7 +129,7 @@
                                                     <action selector="purchaseBeverageWithButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="rfo-GU-Eso"/>
                                                 </connections>
                                             </button>
-                                            <button opaque="NO" tag="2" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="14X-Gx-cnX">
+                                            <button opaque="NO" tag="2" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="14X-Gx-cnX" customClass="PurchaseButton" customModule="VendingMachineApp" customModuleProvider="target">
                                                 <rect key="frame" x="385" y="167" width="30" height="20"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
@@ -140,7 +140,7 @@
                                                     <action selector="purchaseBeverageWithButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="cv7-zQ-lQh"/>
                                                 </connections>
                                             </button>
-                                            <button opaque="NO" tag="3" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eJO-e2-m0c">
+                                            <button opaque="NO" tag="3" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eJO-e2-m0c" customClass="PurchaseButton" customModule="VendingMachineApp" customModuleProvider="target">
                                                 <rect key="frame" x="542" y="167" width="30" height="20"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
@@ -151,7 +151,7 @@
                                                     <action selector="purchaseBeverageWithButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="nB5-3C-WbF"/>
                                                 </connections>
                                             </button>
-                                            <button opaque="NO" tag="4" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="of3-Fp-b9E">
+                                            <button opaque="NO" tag="4" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="of3-Fp-b9E" customClass="PurchaseButton" customModule="VendingMachineApp" customModuleProvider="target">
                                                 <rect key="frame" x="707" y="167" width="30" height="20"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
@@ -162,7 +162,7 @@
                                                     <action selector="purchaseBeverageWithButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="0k5-2g-nGM"/>
                                                 </connections>
                                             </button>
-                                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6SB-7n-J2t">
+                                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6SB-7n-J2t" customClass="PurchaseButton" customModule="VendingMachineApp" customModuleProvider="target">
                                                 <rect key="frame" x="84" y="167" width="30" height="20"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
@@ -332,7 +332,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <button opaque="NO" tag="5" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UwJ-ld-QnP">
+                                            <button opaque="NO" tag="5" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UwJ-ld-QnP" customClass="PurchaseButton" customModule="VendingMachineApp" customModuleProvider="target">
                                                 <rect key="frame" x="84" y="168" width="30" height="20"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
@@ -343,7 +343,7 @@
                                                     <action selector="purchaseBeverageWithButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ddc-9s-xTj"/>
                                                 </connections>
                                             </button>
-                                            <button opaque="NO" tag="7" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JyH-MH-Uhn">
+                                            <button opaque="NO" tag="7" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JyH-MH-Uhn" customClass="PurchaseButton" customModule="VendingMachineApp" customModuleProvider="target">
                                                 <rect key="frame" x="385" y="168" width="30" height="20"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
@@ -354,7 +354,7 @@
                                                     <action selector="purchaseBeverageWithButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="RVn-Z2-jnU"/>
                                                 </connections>
                                             </button>
-                                            <button opaque="NO" tag="8" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EvN-A1-MM4">
+                                            <button opaque="NO" tag="8" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EvN-A1-MM4" customClass="PurchaseButton" customModule="VendingMachineApp" customModuleProvider="target">
                                                 <rect key="frame" x="545" y="168" width="30" height="20"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
@@ -365,7 +365,7 @@
                                                     <action selector="purchaseBeverageWithButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="8P9-2T-NtA"/>
                                                 </connections>
                                             </button>
-                                            <button opaque="NO" tag="6" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="muD-o0-hTH">
+                                            <button opaque="NO" tag="6" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="muD-o0-hTH" customClass="PurchaseButton" customModule="VendingMachineApp" customModuleProvider="target">
                                                 <rect key="frame" x="239" y="169" width="30" height="20"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>

--- a/VendingMachineApp/VendingMachineApp/Model/Beverage/Beverage.swift
+++ b/VendingMachineApp/VendingMachineApp/Model/Beverage/Beverage.swift
@@ -31,7 +31,7 @@ class Beverage: NSObject, NSCoding {
         return "\(manufacturer), \(capacity), \(price), \(brand), \(manufacturedDate.dateToString())"
     }
 
-    init(manufacturer: String, brand: String, capacity: Int, price: Money, name: String, manufacturedDate: Date, expirationDate: Date, temperature: Int) {
+    init(manufacturer: String = "", brand: String = "", capacity: Int = 0, price: Money = Money(), name: String = "", manufacturedDate: Date = Date(), expirationDate: Date = Date(), temperature: Int = 0) {
         self.manufacturer = manufacturer
         self.brand = brand
         self.capacity = capacity

--- a/VendingMachineApp/VendingMachineApp/Model/Money.swift
+++ b/VendingMachineApp/VendingMachineApp/Model/Money.swift
@@ -41,6 +41,7 @@ class Money: NSObject, NSCoding {
     
     func subtract(_ price: Money) {
         balance = self.balance - price.balance
+         NotificationCenter.default.post(name: .updateBalanceLabel, object: "\(balance)")
     }
     
     override var description: String {

--- a/VendingMachineApp/VendingMachineApp/Model/Money.swift
+++ b/VendingMachineApp/VendingMachineApp/Model/Money.swift
@@ -9,7 +9,11 @@
 import Foundation
 class Money: NSObject, NSCoding {
 
-    private var balance: Int
+    private var balance: Int {
+        didSet {
+            postNotification()
+        }
+    }
     
     enum MoneyUnit: Int {
         case fiveThousand = 5000
@@ -29,10 +33,13 @@ class Money: NSObject, NSCoding {
     func encode(with coder: NSCoder) {
         coder.encode(self.balance, forKey: "moneyBalance")
     }
+    
+    func postNotification() {
+        NotificationCenter.default.post(name: .balanceChanged, object: nil, userInfo: ["balance":"\(balance)"])
+    }
         
     func raiseMoney(moneyUnit: MoneyUnit) {
         balance += moneyUnit.rawValue
-        NotificationCenter.default.post(name: .updateBalanceLabel, object: "\(balance)")
     }
     
     func confirmBalance(_ money: Money) {
@@ -41,7 +48,6 @@ class Money: NSObject, NSCoding {
     
     func subtract(_ price: Money) {
         balance = self.balance - price.balance
-         NotificationCenter.default.post(name: .updateBalanceLabel, object: "\(balance)")
     }
     
     override var description: String {

--- a/VendingMachineApp/VendingMachineApp/Model/VendingMachine.swift
+++ b/VendingMachineApp/VendingMachineApp/Model/VendingMachine.swift
@@ -115,10 +115,11 @@ class VendingMachine: NSObject, NSCoding {
         balance.raiseMoney(moneyUnit: moneyUnit)
     }
 
-    func addStock(_ index: Int) {
-        beverages.addBeverage(products[index])
-         let beverageCount = beverages.reportBeverageCount(products[index])
-         NotificationCenter.default.post(name: .updateBeverageCountLabel, object: (index, beverageCount))
+    func addStock(_ beverage: Beverage) {
+        beverages.addBeverage(beverage)
+        let beverageSequence = reportProductIndex(beverage)
+         let beverageCount = beverages.reportBeverageCount(beverage)
+        NotificationCenter.default.post(name: .updateBeverageCountLabel, object: nil, userInfo: ["bevSeqeunceCount":(beverageSequence, beverageCount)])
     }
 
     func reportAvailableBeverageNowMoney() -> [Beverage] {

--- a/VendingMachineApp/VendingMachineApp/Model/VendingMachine.swift
+++ b/VendingMachineApp/VendingMachineApp/Model/VendingMachine.swift
@@ -166,6 +166,6 @@ class VendingMachine: NSObject, NSCoding {
     func postNotificationChangePurchaseList(_ beverage: Beverage) {
         let beverageSequence = reportProductIndex(beverage)
 
-        NotificationCenter.default.post(name: .updatePurchasedImages, object: nil, userInfo: ["beverageNSequence" : (beverageSequence, purchasedList.count)])
+        NotificationCenter.default.post(name: .purchasedListChanged, object: nil, userInfo: ["beverageNSequence" : (beverageSequence, purchasedList.count)])
     }
 }

--- a/VendingMachineApp/VendingMachineApp/Model/VendingMachine.swift
+++ b/VendingMachineApp/VendingMachineApp/Model/VendingMachine.swift
@@ -128,6 +128,7 @@ class VendingMachine: NSObject, NSCoding {
         
       let beverageCount = beverages.reportBeverageCount(products[index])
         NotificationCenter.default.post(name: .updateBeverageCountLabel, object: (index, beverageCount))
+        
         NotificationCenter.default.post(name: .updatePurchasedImages, object: (index, purchasedList.count))
     }
 

--- a/VendingMachineApp/VendingMachineApp/Model/VendingMachine.swift
+++ b/VendingMachineApp/VendingMachineApp/Model/VendingMachine.swift
@@ -125,6 +125,10 @@ class VendingMachine: NSObject, NSCoding {
         balance.subtract(products[index].price)
         beverages.removeBeverage(products[index])
         purchasedList.append(products[index])
+        
+      let beverageCount = beverages.reportBeverageCount(products[index])
+        NotificationCenter.default.post(name: .updateBeverageCountLabel, object: (index, beverageCount))
+        NotificationCenter.default.post(name: .updatePurchasedImages, object: (index, purchasedList.count))
     }
 
     func confirmBalance() -> Money {

--- a/VendingMachineApp/VendingMachineApp/Model/VendingMachine.swift
+++ b/VendingMachineApp/VendingMachineApp/Model/VendingMachine.swift
@@ -69,7 +69,7 @@ class VendingMachine: NSObject, NSCoding {
         let coke = coder.decodeObject(forKey: cokeString) as? Coke
         let cider = coder.decodeObject(forKey: ciderString) as? Cider
         let milkis = coder.decodeObject(forKey: milkisString) as? Milkis
-
+        
         self.beverages = beverages ?? Beverages()
         self.balance = balance ?? Money()
         self.purchasedList = purchasedList ?? []
@@ -86,8 +86,8 @@ class VendingMachine: NSObject, NSCoding {
         self.coke = coke ?? Coke()
         self.cider = cider ?? Cider()
         self.milkis = milkis ?? Milkis()
-     }
-     
+    }
+    
     func encode(with coder: NSCoder) {
         coder.encode(self.beverages, forKey: beveragesString)
         coder.encode(self.balance, forKey: balanceString)
@@ -114,30 +114,25 @@ class VendingMachine: NSObject, NSCoding {
     func raiseMoney(moneyUnit: Money.MoneyUnit) {
         balance.raiseMoney(moneyUnit: moneyUnit)
     }
-
+    
     func addStock(_ beverage: Beverage) {
         beverages.addBeverage(beverage)
-        let beverageSequence = reportProductIndex(beverage)
-         let beverageCount = beverages.reportBeverageCount(beverage)
-        NotificationCenter.default.post(name: .updateBeverageCountLabel, object: nil, userInfo: ["bevSeqeunceCount":(beverageSequence, beverageCount)])
+       postNotificationChangeStock(beverage)
     }
-
+    
     func reportAvailableBeverageNowMoney() -> [Beverage] {
         return beverages.reportAvailableBeverageNowMoney(confirmBalance())
     }
-
+    
     func purchaseBeverage(_ beverage: Beverage) {
         balance.subtract(beverage.price)
         beverages.removeBeverage(beverage)
         purchasedList.append(beverage)
         
-      let beverageCount = beverages.reportBeverageCount(beverage)
-//        NotificationCenter.default.post(name: .updateBeverageCountLabel, object: (index, beverageCount))
-
-        let beverageIndex = reportProductIndex(beverage)
-        NotificationCenter.default.post(name: .updatePurchasedImages, object: nil, userInfo: ["beverageNSequence" : (beverageIndex, purchasedList.count)])
+        postNotificationChangeStock(beverage)
+        postNotificationChangePurchaseList(beverage)
     }
-
+    
     func confirmBalance() -> Money {
         return balance
     }
@@ -149,9 +144,9 @@ class VendingMachine: NSObject, NSCoding {
     func reportExpiratedBeverage() -> [Beverage] {
         return beverages.reportExpiratedBeverage()
     }
-
+    
     func verifyHotBeverages() -> [Beverage] {
-       return beverages.verifyHotBeverages()
+        return beverages.verifyHotBeverages()
     }
     
     func reportPurchasedHistory() -> [Beverage] {
@@ -162,4 +157,15 @@ class VendingMachine: NSObject, NSCoding {
         return products.firstIndex(of: beverage)
     }
     
+    func postNotificationChangeStock(_ beverage: Beverage) {
+        let beverageSequence = reportProductIndex(beverage)
+        let beverageCount = beverages.reportBeverageCount(beverage)
+        NotificationCenter.default.post(name: .beverageCountChanged, object: nil, userInfo: ["bevSeqeunceCount":(beverageSequence, beverageCount)])
+    }
+    
+    func postNotificationChangePurchaseList(_ beverage: Beverage) {
+        let beverageSequence = reportProductIndex(beverage)
+
+        NotificationCenter.default.post(name: .updatePurchasedImages, object: nil, userInfo: ["beverageNSequence" : (beverageSequence, purchasedList.count)])
+    }
 }

--- a/VendingMachineApp/VendingMachineApp/Model/VendingMachine.swift
+++ b/VendingMachineApp/VendingMachineApp/Model/VendingMachine.swift
@@ -10,7 +10,11 @@ import Foundation
 class VendingMachine: NSObject, NSCoding {
     private var beverages: Beverages
     private(set) var balance: Money
-    private var purchasedList: [Beverage]
+    private var purchasedList: [Beverage] {
+        didSet {
+            
+        }
+    }
     var products: [Beverage]
     var bananaMilk = BananMilk(manufacturer: "연세우유", brand: "곰곰", capacity: 200, price: Money(balance: 1200), name: "곰곰 바나나우유", manufacturedDate: Date(), expirationDate: Date(), fatRatio: .original, isLactoFree: false, temperature: 8, bananaCountry: "케냐")
     var chocoMilk = ChocoMilk(manufacturer: "덴마크우유", brand: "덴마크우유", capacity: 300, price: Money(balance: 1600), name: "초코초코우유", manufacturedDate: Date(), expirationDate: Date(), fatRatio: .lower, isLactoFree: false, temperature: 8, chocolateRatio: 30.0)
@@ -121,15 +125,16 @@ class VendingMachine: NSObject, NSCoding {
         return beverages.reportAvailableBeverageNowMoney(confirmBalance())
     }
 
-    func purchaseBeverage(index: Int) {
-        balance.subtract(products[index].price)
-        beverages.removeBeverage(products[index])
-        purchasedList.append(products[index])
+    func purchaseBeverage(_ beverage: Beverage) {
+        balance.subtract(beverage.price)
+        beverages.removeBeverage(beverage)
+        purchasedList.append(beverage)
         
-      let beverageCount = beverages.reportBeverageCount(products[index])
-        NotificationCenter.default.post(name: .updateBeverageCountLabel, object: (index, beverageCount))
-        
-        NotificationCenter.default.post(name: .updatePurchasedImages, object: (index, purchasedList.count))
+      let beverageCount = beverages.reportBeverageCount(beverage)
+//        NotificationCenter.default.post(name: .updateBeverageCountLabel, object: (index, beverageCount))
+
+        let beverageIndex = reportProductIndex(beverage)
+        NotificationCenter.default.post(name: .updatePurchasedImages, object: nil, userInfo: ["beverageNSequence" : (beverageIndex, purchasedList.count)])
     }
 
     func confirmBalance() -> Money {

--- a/VendingMachineApp/VendingMachineApp/Model/VendingMachineManager.swift
+++ b/VendingMachineApp/VendingMachineApp/Model/VendingMachineManager.swift
@@ -33,4 +33,12 @@ class VendingMachineManager {
         return vendingMachine
     }
     
+    func resetData() {
+        let defaults = UserDefaults.standard
+        let dictionary = defaults.dictionaryRepresentation()
+        dictionary.keys.forEach { key in
+            defaults.removeObject(forKey: key)
+        }
+    }
+    
 }

--- a/VendingMachineApp/VendingMachineApp/View/AddStockButton.swift
+++ b/VendingMachineApp/VendingMachineApp/View/AddStockButton.swift
@@ -1,0 +1,25 @@
+//
+//  AddStockButton.swift
+//  VendingMachineApp
+//
+//  Created by delma on 2020/03/15.
+//  Copyright © 2020 delma. All rights reserved.
+//
+
+import UIKit
+
+class AddStockButton: UIButton {
+    
+    var beverage: Beverage
+    
+    override init(frame: CGRect) {
+        self.beverage = Beverage()
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        self.beverage = Beverage()
+        super.init(coder: coder)
+    }
+    
+}

--- a/VendingMachineApp/VendingMachineApp/View/PurchaseButton.swift
+++ b/VendingMachineApp/VendingMachineApp/View/PurchaseButton.swift
@@ -1,0 +1,25 @@
+//
+//  PurchaseButton.swift
+//  VendingMachineApp
+//
+//  Created by delma on 2020/03/15.
+//  Copyright © 2020 delma. All rights reserved.
+//
+
+import UIKit
+class PurchaseButton: UIButton {
+
+    var beverage: Beverage
+    
+    override init(frame: CGRect) {
+        self.beverage = Beverage()
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        self.beverage = Beverage()
+        super.init(coder: coder)
+    }
+    
+    
+}

--- a/VendingMachineApp/VendingMachineApp/View/StockCountLabel.swift
+++ b/VendingMachineApp/VendingMachineApp/View/StockCountLabel.swift
@@ -1,0 +1,25 @@
+//
+//  StockCountLabel.swift
+//  VendingMachineApp
+//
+//  Created by delma on 2020/03/15.
+//  Copyright © 2020 delma. All rights reserved.
+//
+
+import UIKit
+
+class StockCountLabel: UILabel {
+    
+    var beverage: Beverage
+    
+    override init(frame: CGRect) {
+        self.beverage = Beverage()
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        self.beverage = Beverage()
+        super.init(coder: coder)
+    }
+    
+}

--- a/VendingMachineApp/VendingMachineApp/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/ViewController.swift
@@ -16,15 +16,20 @@ class ViewController: UIViewController {
     @IBOutlet var backgroundViews: [UIView]!
     @IBOutlet var addStockButtons: [UIButton]!
     @IBOutlet var stockCountLabels: [UILabel]!
-    @IBOutlet var beverageImages: [UIImageView]!
+    @IBOutlet var beverageImageViews: [UIImageView]!
     @IBOutlet var addMoneyButtons: [UIButton]!
     @IBOutlet var balanceLabel: UILabel!
-     
+    let beverageImages: [UIImage] = [#imageLiteral(resourceName: "bananaMilk"), #imageLiteral(resourceName: "ChocoMilk"), #imageLiteral(resourceName: "strawberryMilk"), #imageLiteral(resourceName: "Americano"), #imageLiteral(resourceName: "Latte"), #imageLiteral(resourceName: "Mocha"), #imageLiteral(resourceName: "Coke"), #imageLiteral(resourceName: "Cider"), #imageLiteral(resourceName: "milkis")]
+
+    @IBOutlet var purchaseButtons: [UIButton]!
+    
+    
     override func viewDidLoad() {
         vendingMachine = appDelegate.vendingMachine
         
         balanceLabel.text = vendingMachine?.balance.description
         updateSavedBeverageCountLabel()
+        
         super.viewDidLoad()
         setUI()
         setNotificationCenter()
@@ -34,10 +39,11 @@ class ViewController: UIViewController {
     func setNotificationCenter() {
         NotificationCenter.default.addObserver(self, selector: #selector(updateBalanceLabel(_:)), name: .updateBalanceLabel, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(updateBeverageCountLabel(_:)), name: .updateBeverageCountLabel, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(updatePurchasedImages(_:)), name: .updatePurchasedImages, object: nil)
     }
     
     func setBeverageImageCornerRadius() {
-        for img in beverageImages {
+        for img in beverageImageViews {
             img.layer.cornerRadius = 30.0
         }
     }
@@ -47,6 +53,7 @@ class ViewController: UIViewController {
             view.layer.cornerRadius = 20.0
         }
     }
+
     func setUI() {
         setBeverageImageCornerRadius()
         setBackgroundViewCornerRadius()
@@ -59,6 +66,19 @@ class ViewController: UIViewController {
     
     @IBAction func addMoney(button: UIButton) {
         vendingMachine?.raiseMoney(moneyUnit: Money.MoneyUnit(rawValue: button.tag)!)
+    }
+    
+    @IBAction func purchaseBeverage(button: UIButton) {
+        vendingMachine?.purchaseBeverage(index: button.tag)
+    }
+    
+    @objc func updatePurchasedImages(_ notification: Notification) {
+        let purchasedViewIndex = 3
+        let imageCounts = notification.object as! (index: Int, purchasedCount: Int)
+        let downPositionX = imageCounts.purchasedCount * 50
+        let image: UIImageView = UIImageView(image: beverageImages[imageCounts.index])
+        image.frame = CGRect(x: downPositionX, y: 30, width: 80, height: 110)
+        backgroundViews[purchasedViewIndex].addSubview(image)
     }
     
     @objc func updateBeverageCountLabel(_ notification: Notification) {
@@ -74,6 +94,7 @@ class ViewController: UIViewController {
     deinit {
         NotificationCenter.default.removeObserver(self, name: .updateBalanceLabel, object: nil)
         NotificationCenter.default.removeObserver(self, name: .updateBeverageCountLabel, object: nil)
+        NotificationCenter.default.removeObserver(self, name: .updatePurchasedImages, object: nil)
     }
     
     func updateSavedBeverageCountLabel() {
@@ -90,5 +111,6 @@ class ViewController: UIViewController {
 extension Notification.Name {
     static let updateBalanceLabel =  NSNotification.Name("updateBalanceLabel")
     static let updateBeverageCountLabel = NSNotification.Name("updateBeverageCountLabel")
+    static let updatePurchasedImages = Notification.Name("updatePurchasedImages")
 }
 

--- a/VendingMachineApp/VendingMachineApp/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/ViewController.swift
@@ -14,8 +14,8 @@ class ViewController: UIViewController {
     var vendingMachine: VendingMachine?
     
     @IBOutlet var backgroundViews: [UIView]!
-    @IBOutlet var addStockButtons: [UIButton]!
-    @IBOutlet var stockCountLabels: [UILabel]!
+    @IBOutlet var addStockButtons: [AddStockButton]!
+    @IBOutlet var stockCountLabels: [StockCountLabel]!
     @IBOutlet var beverageImageViews: [UIImageView]!
     @IBOutlet var addMoneyButtons: [UIButton]!
     @IBOutlet var balanceLabel: UILabel!
@@ -33,13 +33,31 @@ class ViewController: UIViewController {
         super.viewDidLoad()
         setUI()
         setNotificationCenter()
-        setPurchaseButtonBeverage()
+        connectPurchaseButtonWithBeverage()
+        connectAddStockButtonWithBeverage()
+        connectStockCountLabelWithBeverage()
     }
     
-    func setPurchaseButtonBeverage() {
+    func connectPurchaseButtonWithBeverage() {
         var index = 0
         for button in purchaseButtons {
             button.beverage = vendingMachine!.products[index]
+            index += 1
+        }
+    }
+    
+    func connectAddStockButtonWithBeverage() {
+        var index = 0
+        for button in addStockButtons {
+            button.beverage = vendingMachine!.products[index]
+            index += 1
+        }
+    }
+    
+    func connectStockCountLabelWithBeverage() {
+        var index = 0
+        for label in stockCountLabels {
+            label.beverage = vendingMachine!.products[index]
             index += 1
         }
     }
@@ -68,8 +86,8 @@ class ViewController: UIViewController {
         
     }
     
-    @IBAction func addStock(button: UIButton) {
-        vendingMachine?.addStock(button.tag)
+    @IBAction func addStock(button: AddStockButton) {
+        vendingMachine?.addStock(button.beverage)
     }
     
     @IBAction func addMoney(button: UIButton) {
@@ -91,8 +109,9 @@ class ViewController: UIViewController {
     }
     
     @objc func updateBeverageCountLabel(_ notification: Notification) {
-        let stockCount = notification.object as! (index: Int, count: Int)
-        stockCountLabels[stockCount.index].text = String(stockCount.count)
+        guard let bevSeqeunceCount = notification.userInfo?["bevSeqeunceCount"] as? (beverageSequence: Int, beverageCount: Int) else { return }
+    
+        stockCountLabels[bevSeqeunceCount.beverageSequence].text = String(bevSeqeunceCount.beverageCount)
     }
     
     @objc func updateBalanceLabel(_ notification: Notification) {

--- a/VendingMachineApp/VendingMachineApp/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/ViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 class ViewController: UIViewController {
-   
+    
     let appDelegate = UIApplication.shared.delegate as! AppDelegate
     var vendingMachine: VendingMachine?
     
@@ -20,7 +20,7 @@ class ViewController: UIViewController {
     @IBOutlet var addMoneyButtons: [UIButton]!
     @IBOutlet var balanceLabel: UILabel!
     let beverageImages: [UIImage] = [#imageLiteral(resourceName: "bananaMilk"), #imageLiteral(resourceName: "ChocoMilk"), #imageLiteral(resourceName: "strawberryMilk"), #imageLiteral(resourceName: "Americano"), #imageLiteral(resourceName: "Latte"), #imageLiteral(resourceName: "Mocha"), #imageLiteral(resourceName: "Coke"), #imageLiteral(resourceName: "Cider"), #imageLiteral(resourceName: "milkis")]
-
+    
     @IBOutlet var purchaseButtons: [UIButton]!
     
     
@@ -29,11 +29,11 @@ class ViewController: UIViewController {
         
         balanceLabel.text = vendingMachine?.balance.description
         updateSavedBeverageCountLabel()
+        updateSavedPurchasedListImages()
         
         super.viewDidLoad()
         setUI()
         setNotificationCenter()
-
     }
     
     func setNotificationCenter() {
@@ -53,7 +53,7 @@ class ViewController: UIViewController {
             view.layer.cornerRadius = 20.0
         }
     }
-
+    
     func setUI() {
         setBeverageImageCornerRadius()
         setBackgroundViewCornerRadius()
@@ -75,7 +75,7 @@ class ViewController: UIViewController {
     @objc func updatePurchasedImages(_ notification: Notification) {
         let purchasedViewIndex = 3
         let imageCounts = notification.object as! (index: Int, purchasedCount: Int)
-        let downPositionX = imageCounts.purchasedCount * 50
+        let downPositionX = (imageCounts.purchasedCount-1) * 50
         let image: UIImageView = UIImageView(image: beverageImages[imageCounts.index])
         image.frame = CGRect(x: downPositionX, y: 30, width: 80, height: 110)
         backgroundViews[purchasedViewIndex].addSubview(image)
@@ -104,6 +104,18 @@ class ViewController: UIViewController {
                 guard let index = vendingMachine?.reportProductIndex(key) else { return }
                 stockCountLabels[index].text = String(value)
             }
+        }
+    }
+    
+    func updateSavedPurchasedListImages() {
+        guard let purchasedList = vendingMachine?.reportPurchasedHistory() else { return }
+        for purchasedIndex in 0..<purchasedList.count {
+            let purchasedViewIndex = 3
+            let downPositionX = purchasedIndex * 50
+            guard let productIndex = vendingMachine?.reportProductIndex(purchasedList[purchasedIndex]) else { return }
+            let image: UIImageView = UIImageView(image: beverageImages[productIndex])
+            image.frame = CGRect(x: downPositionX, y: 30, width: 80, height: 110)
+            backgroundViews[purchasedViewIndex].addSubview(image)
         }
     }
 }

--- a/VendingMachineApp/VendingMachineApp/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/ViewController.swift
@@ -19,21 +19,29 @@ class ViewController: UIViewController {
     @IBOutlet var beverageImageViews: [UIImageView]!
     @IBOutlet var addMoneyButtons: [UIButton]!
     @IBOutlet var balanceLabel: UILabel!
+    @IBOutlet var purchaseButtons: [PurchaseButton]!
+    
     let beverageImages: [UIImage] = [#imageLiteral(resourceName: "bananaMilk"), #imageLiteral(resourceName: "ChocoMilk"), #imageLiteral(resourceName: "strawberryMilk"), #imageLiteral(resourceName: "Americano"), #imageLiteral(resourceName: "Latte"), #imageLiteral(resourceName: "Mocha"), #imageLiteral(resourceName: "Coke"), #imageLiteral(resourceName: "Cider"), #imageLiteral(resourceName: "milkis")]
-    
-    @IBOutlet var purchaseButtons: [UIButton]!
-    
     
     override func viewDidLoad() {
         vendingMachine = appDelegate.vendingMachine
         
         balanceLabel.text = vendingMachine?.balance.description
         updateSavedBeverageCountLabel()
-        updateSavedPurchasedListImages()
+//        updateSavedPurchasedListImages()
         
         super.viewDidLoad()
         setUI()
         setNotificationCenter()
+        setPurchaseButtonBeverage()
+    }
+    
+    func setPurchaseButtonBeverage() {
+        var index = 0
+        for button in purchaseButtons {
+            button.beverage = vendingMachine!.products[index]
+            index += 1
+        }
     }
     
     func setNotificationCenter() {
@@ -68,15 +76,16 @@ class ViewController: UIViewController {
         vendingMachine?.raiseMoney(moneyUnit: Money.MoneyUnit(rawValue: button.tag)!)
     }
     
-    @IBAction func purchaseBeverage(button: UIButton) {
-        vendingMachine?.purchaseBeverage(index: button.tag)
+    @IBAction func purchaseBeverage(button: PurchaseButton) {
+        vendingMachine?.purchaseBeverage(button.beverage)
     }
     
     @objc func updatePurchasedImages(_ notification: Notification) {
+        guard let beverageIndexes = notification.userInfo?["beverageNSequence"] as? (beverageIndex: Int, purchasedSequence: Int) else { return }
         let purchasedViewIndex = 3
-        let imageCounts = notification.object as! (index: Int, purchasedCount: Int)
-        let downPositionX = (imageCounts.purchasedCount-1) * 50
-        let image: UIImageView = UIImageView(image: beverageImages[imageCounts.index])
+        let downPositionX = (beverageIndexes.purchasedSequence-1) * 50
+        
+        let image: UIImageView = UIImageView(image: beverageImages[beverageIndexes.beverageIndex])
         image.frame = CGRect(x: downPositionX, y: 30, width: 80, height: 110)
         backgroundViews[purchasedViewIndex].addSubview(image)
     }
@@ -107,17 +116,17 @@ class ViewController: UIViewController {
         }
     }
     
-    func updateSavedPurchasedListImages() {
-        guard let purchasedList = vendingMachine?.reportPurchasedHistory() else { return }
-        for purchasedIndex in 0..<purchasedList.count {
-            let purchasedViewIndex = 3
-            let downPositionX = purchasedIndex * 50
-            guard let productIndex = vendingMachine?.reportProductIndex(purchasedList[purchasedIndex]) else { return }
-            let image: UIImageView = UIImageView(image: beverageImages[productIndex])
-            image.frame = CGRect(x: downPositionX, y: 30, width: 80, height: 110)
-            backgroundViews[purchasedViewIndex].addSubview(image)
-        }
-    }
+//    func updateSavedPurchasedListImages() {
+//        guard let purchasedList = vendingMachine?.reportPurchasedHistory() else { return }
+//        for purchasedIndex in 0..<purchasedList.count {
+//            let purchasedViewIndex = 3
+//            let downPositionX = purchasedIndex * 50
+//            guard let productIndex = vendingMachine?.reportProductIndex(purchasedList[purchasedIndex]) else { return }
+//            let image: UIImageView = UIImageView(image: beverageImages[productIndex])
+//            image.frame = CGRect(x: downPositionX, y: 30, width: 80, height: 110)
+//            backgroundViews[purchasedViewIndex].addSubview(image)
+//        }
+//    }
 }
 
 extension Notification.Name {

--- a/VendingMachineApp/VendingMachineApp/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/ViewController.swift
@@ -28,7 +28,7 @@ class ViewController: UIViewController {
         
         balanceLabel.text = vendingMachine?.balance.description
         updateSavedBeverageCountLabel()
-//        updateSavedPurchasedListImages()
+        updateSavedPurchasedListImages()
         
         super.viewDidLoad()
         setUI()
@@ -64,7 +64,7 @@ class ViewController: UIViewController {
     
     func setNotificationCenter() {
         NotificationCenter.default.addObserver(self, selector: #selector(updateBalanceLabel(_:)), name: .balanceChanged, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(updateBeverageCountLabel(_:)), name: .updateBeverageCountLabel, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(updateBeverageCountLabel(_:)), name: .beverageCountChanged, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(updatePurchasedImages(_:)), name: .updatePurchasedImages, object: nil)
     }
     
@@ -121,7 +121,7 @@ class ViewController: UIViewController {
     
     deinit {
         NotificationCenter.default.removeObserver(self, name: .balanceChanged, object: nil)
-        NotificationCenter.default.removeObserver(self, name: .updateBeverageCountLabel, object: nil)
+        NotificationCenter.default.removeObserver(self, name: .beverageCountChanged, object: nil)
         NotificationCenter.default.removeObserver(self, name: .updatePurchasedImages, object: nil)
     }
     
@@ -135,22 +135,22 @@ class ViewController: UIViewController {
         }
     }
     
-//    func updateSavedPurchasedListImages() {
-//        guard let purchasedList = vendingMachine?.reportPurchasedHistory() else { return }
-//        for purchasedIndex in 0..<purchasedList.count {
-//            let purchasedViewIndex = 3
-//            let downPositionX = purchasedIndex * 50
-//            guard let productIndex = vendingMachine?.reportProductIndex(purchasedList[purchasedIndex]) else { return }
-//            let image: UIImageView = UIImageView(image: beverageImages[productIndex])
-//            image.frame = CGRect(x: downPositionX, y: 30, width: 80, height: 110)
-//            backgroundViews[purchasedViewIndex].addSubview(image)
-//        }
-//    }
+    func updateSavedPurchasedListImages() {
+        guard let purchasedList = vendingMachine?.reportPurchasedHistory() else { return }
+        for purchasedIndex in 0..<purchasedList.count {
+            let purchasedViewIndex = 3
+            let downPositionX = purchasedIndex * 50
+            guard let productIndex = vendingMachine?.reportProductIndex(purchasedList[purchasedIndex]) else { return }
+            let image: UIImageView = UIImageView(image: beverageImages[productIndex])
+            image.frame = CGRect(x: downPositionX, y: 30, width: 80, height: 110)
+            backgroundViews[purchasedViewIndex].addSubview(image)
+        }
+    }
 }
 
 extension Notification.Name {
     static let balanceChanged =  NSNotification.Name("balanceChanged")
-    static let updateBeverageCountLabel = NSNotification.Name("updateBeverageCountLabel")
+    static let beverageCountChanged = NSNotification.Name("beverageCountChanged")
     static let updatePurchasedImages = Notification.Name("updatePurchasedImages")
 }
 

--- a/VendingMachineApp/VendingMachineApp/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/ViewController.swift
@@ -37,7 +37,7 @@ class ViewController: UIViewController {
     }
     
     func setNotificationCenter() {
-        NotificationCenter.default.addObserver(self, selector: #selector(updateBalanceLabel(_:)), name: .updateBalanceLabel, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(updateBalanceLabel(_:)), name: .balanceChanged, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(updateBeverageCountLabel(_:)), name: .updateBeverageCountLabel, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(updatePurchasedImages(_:)), name: .updatePurchasedImages, object: nil)
     }
@@ -87,12 +87,12 @@ class ViewController: UIViewController {
     }
     
     @objc func updateBalanceLabel(_ notification: Notification) {
-        let balance = notification.object as! String
+        guard let balance = notification.userInfo?["balance"] as? String else { return }
         balanceLabel.text = balance
     }
     
     deinit {
-        NotificationCenter.default.removeObserver(self, name: .updateBalanceLabel, object: nil)
+        NotificationCenter.default.removeObserver(self, name: .balanceChanged, object: nil)
         NotificationCenter.default.removeObserver(self, name: .updateBeverageCountLabel, object: nil)
         NotificationCenter.default.removeObserver(self, name: .updatePurchasedImages, object: nil)
     }
@@ -121,7 +121,7 @@ class ViewController: UIViewController {
 }
 
 extension Notification.Name {
-    static let updateBalanceLabel =  NSNotification.Name("updateBalanceLabel")
+    static let balanceChanged =  NSNotification.Name("balanceChanged")
     static let updateBeverageCountLabel = NSNotification.Name("updateBeverageCountLabel")
     static let updatePurchasedImages = Notification.Name("updatePurchasedImages")
 }

--- a/VendingMachineApp/VendingMachineApp/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/ViewController.swift
@@ -65,7 +65,7 @@ class ViewController: UIViewController {
     func setNotificationCenter() {
         NotificationCenter.default.addObserver(self, selector: #selector(updateBalanceLabel(_:)), name: .balanceChanged, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(updateBeverageCountLabel(_:)), name: .beverageCountChanged, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(updatePurchasedImages(_:)), name: .updatePurchasedImages, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(updatePurchasedImages(_:)), name: .purchasedListChanged, object: nil)
     }
     
     func setBeverageImageCornerRadius() {
@@ -110,7 +110,6 @@ class ViewController: UIViewController {
     
     @objc func updateBeverageCountLabel(_ notification: Notification) {
         guard let bevSeqeunceCount = notification.userInfo?["bevSeqeunceCount"] as? (beverageSequence: Int, beverageCount: Int) else { return }
-    
         stockCountLabels[bevSeqeunceCount.beverageSequence].text = String(bevSeqeunceCount.beverageCount)
     }
     
@@ -122,7 +121,7 @@ class ViewController: UIViewController {
     deinit {
         NotificationCenter.default.removeObserver(self, name: .balanceChanged, object: nil)
         NotificationCenter.default.removeObserver(self, name: .beverageCountChanged, object: nil)
-        NotificationCenter.default.removeObserver(self, name: .updatePurchasedImages, object: nil)
+        NotificationCenter.default.removeObserver(self, name: .purchasedListChanged, object: nil)
     }
     
     func updateSavedBeverageCountLabel() {
@@ -151,6 +150,5 @@ class ViewController: UIViewController {
 extension Notification.Name {
     static let balanceChanged =  NSNotification.Name("balanceChanged")
     static let beverageCountChanged = NSNotification.Name("beverageCountChanged")
-    static let updatePurchasedImages = Notification.Name("updatePurchasedImages")
+    static let purchasedListChanged = Notification.Name("purchasedListChanged")
 }
-

--- a/VendingMachineApp/VendingMachineApp/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/ViewController.swift
@@ -100,12 +100,7 @@ class ViewController: UIViewController {
     
     @objc func updatePurchasedImages(_ notification: Notification) {
         guard let beverageIndexes = notification.userInfo?["beverageNSequence"] as? (beverageIndex: Int, purchasedSequence: Int) else { return }
-        let purchasedViewIndex = 3
-        let downPositionX = (beverageIndexes.purchasedSequence-1) * 50
-        
-        let image: UIImageView = UIImageView(image: beverageImages[beverageIndexes.beverageIndex])
-        image.frame = CGRect(x: downPositionX, y: 30, width: 80, height: 110)
-        backgroundViews[purchasedViewIndex].addSubview(image)
+        drawPurchasedBeverage(beverageIndex: beverageIndexes.beverageIndex, purchasedSequence: beverageIndexes.purchasedSequence-1)
     }
     
     @objc func updateBeverageCountLabel(_ notification: Notification) {
@@ -137,13 +132,18 @@ class ViewController: UIViewController {
     func updateSavedPurchasedListImages() {
         guard let purchasedList = vendingMachine?.reportPurchasedHistory() else { return }
         for purchasedIndex in 0..<purchasedList.count {
-            let purchasedViewIndex = 3
-            let downPositionX = purchasedIndex * 50
-            guard let productIndex = vendingMachine?.reportProductIndex(purchasedList[purchasedIndex]) else { return }
-            let image: UIImageView = UIImageView(image: beverageImages[productIndex])
-            image.frame = CGRect(x: downPositionX, y: 30, width: 80, height: 110)
-            backgroundViews[purchasedViewIndex].addSubview(image)
+            guard let beverageIndex = vendingMachine?.reportProductIndex(purchasedList[purchasedIndex]) else { return }
+            drawPurchasedBeverage(beverageIndex: beverageIndex, purchasedSequence: purchasedIndex)
         }
+    }
+    
+    func drawPurchasedBeverage(beverageIndex: Int, purchasedSequence: Int) {
+        let purchasedViewIndex = 3
+        let downPositionX = purchasedSequence * 50
+        
+        let image: UIImageView = UIImageView(image: beverageImages[beverageIndex])
+        image.frame = CGRect(x: downPositionX, y: 30, width: 80, height: 110)
+        backgroundViews[purchasedViewIndex].addSubview(image)
     }
 }
 


### PR DESCRIPTION
- 구매 버튼 추가
- 이전 구매 목록 데이터 불러오기
- 구매 버튼 클릭시 모델에 
 1. 돈 차감 2. 재고에서 음료 삭제 3. 구매 목록에 추가 변화가 일어납니다. 
 이러한 모델의 변화를 노티로 컨트롤러에서 감지해 
 뷰에 1. 돈 잔액 라벨 변경 2. 재고 라벨 변경 3. 구매 목록에 이미지 추가 와 같은 변화가 일어나도록 적용해주었습니다. 

재고가 0이거나 잔액이 음료의 가격보다 부족할때 구매 버튼을 누르면 
알럿창을 띄운다던지 구매를 막을 수 있도록 하는 조치는 
피드백 반영하면서 함께 적용해보겠습니다.!