### PR TITLE
[1song2(쏭)] Step1 - Superclass 'Beverage'의 Subclass 구현 및 객체 생성

### DIFF
--- a/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
+++ b/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		E4E22CE725E51B27008CA611 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E4E22CE525E51B27008CA611 /* Main.storyboard */; };
 		E4E22CE925E51B28008CA611 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E4E22CE825E51B28008CA611 /* Assets.xcassets */; };
 		E4E22CEC25E51B28008CA611 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E4E22CEA25E51B28008CA611 /* LaunchScreen.storyboard */; };
+		E4E22CF625E51E11008CA611 /* Beverage.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E22CF525E51E11008CA611 /* Beverage.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -24,6 +25,7 @@
 		E4E22CE825E51B28008CA611 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		E4E22CEB25E51B28008CA611 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		E4E22CED25E51B28008CA611 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E4E22CF525E51E11008CA611 /* Beverage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Beverage.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -59,6 +61,7 @@
 				E4E22CDF25E51B27008CA611 /* AppDelegate.swift */,
 				E4E22CE125E51B27008CA611 /* SceneDelegate.swift */,
 				E4E22CE325E51B27008CA611 /* ViewController.swift */,
+				E4E22CF525E51E11008CA611 /* Beverage.swift */,
 				E4E22CE525E51B27008CA611 /* Main.storyboard */,
 				E4E22CE825E51B28008CA611 /* Assets.xcassets */,
 				E4E22CEA25E51B28008CA611 /* LaunchScreen.storyboard */,
@@ -139,6 +142,7 @@
 			files = (
 				E4E22CE425E51B27008CA611 /* ViewController.swift in Sources */,
 				E4E22CE025E51B27008CA611 /* AppDelegate.swift in Sources */,
+				E4E22CF625E51E11008CA611 /* Beverage.swift in Sources */,
 				E4E22CE225E51B27008CA611 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
+++ b/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		E4D472A725E5ED65007FAAA0 /* VendingMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D472A625E5ED65007FAAA0 /* VendingMachine.swift */; };
 		E4E22CE025E51B27008CA611 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E22CDF25E51B27008CA611 /* AppDelegate.swift */; };
 		E4E22CE225E51B27008CA611 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E22CE125E51B27008CA611 /* SceneDelegate.swift */; };
 		E4E22CE425E51B27008CA611 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E22CE325E51B27008CA611 /* ViewController.swift */; };
@@ -20,6 +21,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		E4D472A625E5ED65007FAAA0 /* VendingMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VendingMachine.swift; sourceTree = "<group>"; };
 		E4E22CDC25E51B27008CA611 /* VendingMachineApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = VendingMachineApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E4E22CDF25E51B27008CA611 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E4E22CE125E51B27008CA611 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -71,6 +73,7 @@
 				E4E22D1A25E5EAEB008CA611 /* Milk.swift */,
 				E4E22D1D25E5EC53008CA611 /* SoftDrink.swift */,
 				E4E22D2025E5ECC6008CA611 /* Coffee.swift */,
+				E4D472A625E5ED65007FAAA0 /* VendingMachine.swift */,
 				E4E22CE525E51B27008CA611 /* Main.storyboard */,
 				E4E22CE825E51B28008CA611 /* Assets.xcassets */,
 				E4E22CEA25E51B28008CA611 /* LaunchScreen.storyboard */,
@@ -156,6 +159,7 @@
 				E4E22D1E25E5EC53008CA611 /* SoftDrink.swift in Sources */,
 				E4E22D1B25E5EAEB008CA611 /* Milk.swift in Sources */,
 				E4E22D2125E5ECC6008CA611 /* Coffee.swift in Sources */,
+				E4D472A725E5ED65007FAAA0 /* VendingMachine.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
+++ b/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		E4E22CE925E51B28008CA611 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E4E22CE825E51B28008CA611 /* Assets.xcassets */; };
 		E4E22CEC25E51B28008CA611 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E4E22CEA25E51B28008CA611 /* LaunchScreen.storyboard */; };
 		E4E22CF625E51E11008CA611 /* Beverage.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E22CF525E51E11008CA611 /* Beverage.swift */; };
+		E4E22D1B25E5EAEB008CA611 /* Milk.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E22D1A25E5EAEB008CA611 /* Milk.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -26,6 +27,7 @@
 		E4E22CEB25E51B28008CA611 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		E4E22CED25E51B28008CA611 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E4E22CF525E51E11008CA611 /* Beverage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Beverage.swift; sourceTree = "<group>"; };
+		E4E22D1A25E5EAEB008CA611 /* Milk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Milk.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -62,6 +64,7 @@
 				E4E22CE125E51B27008CA611 /* SceneDelegate.swift */,
 				E4E22CE325E51B27008CA611 /* ViewController.swift */,
 				E4E22CF525E51E11008CA611 /* Beverage.swift */,
+				E4E22D1A25E5EAEB008CA611 /* Milk.swift */,
 				E4E22CE525E51B27008CA611 /* Main.storyboard */,
 				E4E22CE825E51B28008CA611 /* Assets.xcassets */,
 				E4E22CEA25E51B28008CA611 /* LaunchScreen.storyboard */,
@@ -144,6 +147,7 @@
 				E4E22CE025E51B27008CA611 /* AppDelegate.swift in Sources */,
 				E4E22CF625E51E11008CA611 /* Beverage.swift in Sources */,
 				E4E22CE225E51B27008CA611 /* SceneDelegate.swift in Sources */,
+				E4E22D1B25E5EAEB008CA611 /* Milk.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
+++ b/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		E4E22CF625E51E11008CA611 /* Beverage.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E22CF525E51E11008CA611 /* Beverage.swift */; };
 		E4E22D1B25E5EAEB008CA611 /* Milk.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E22D1A25E5EAEB008CA611 /* Milk.swift */; };
 		E4E22D1E25E5EC53008CA611 /* SoftDrink.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E22D1D25E5EC53008CA611 /* SoftDrink.swift */; };
+		E4E22D2125E5ECC6008CA611 /* Coffee.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E22D2025E5ECC6008CA611 /* Coffee.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -30,6 +31,7 @@
 		E4E22CF525E51E11008CA611 /* Beverage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Beverage.swift; sourceTree = "<group>"; };
 		E4E22D1A25E5EAEB008CA611 /* Milk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Milk.swift; sourceTree = "<group>"; };
 		E4E22D1D25E5EC53008CA611 /* SoftDrink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoftDrink.swift; sourceTree = "<group>"; };
+		E4E22D2025E5ECC6008CA611 /* Coffee.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coffee.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -68,6 +70,7 @@
 				E4E22CF525E51E11008CA611 /* Beverage.swift */,
 				E4E22D1A25E5EAEB008CA611 /* Milk.swift */,
 				E4E22D1D25E5EC53008CA611 /* SoftDrink.swift */,
+				E4E22D2025E5ECC6008CA611 /* Coffee.swift */,
 				E4E22CE525E51B27008CA611 /* Main.storyboard */,
 				E4E22CE825E51B28008CA611 /* Assets.xcassets */,
 				E4E22CEA25E51B28008CA611 /* LaunchScreen.storyboard */,
@@ -152,6 +155,7 @@
 				E4E22CE225E51B27008CA611 /* SceneDelegate.swift in Sources */,
 				E4E22D1E25E5EC53008CA611 /* SoftDrink.swift in Sources */,
 				E4E22D1B25E5EAEB008CA611 /* Milk.swift in Sources */,
+				E4E22D2125E5ECC6008CA611 /* Coffee.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
+++ b/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		E4E22CEC25E51B28008CA611 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E4E22CEA25E51B28008CA611 /* LaunchScreen.storyboard */; };
 		E4E22CF625E51E11008CA611 /* Beverage.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E22CF525E51E11008CA611 /* Beverage.swift */; };
 		E4E22D1B25E5EAEB008CA611 /* Milk.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E22D1A25E5EAEB008CA611 /* Milk.swift */; };
+		E4E22D1E25E5EC53008CA611 /* SoftDrink.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E22D1D25E5EC53008CA611 /* SoftDrink.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -28,6 +29,7 @@
 		E4E22CED25E51B28008CA611 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E4E22CF525E51E11008CA611 /* Beverage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Beverage.swift; sourceTree = "<group>"; };
 		E4E22D1A25E5EAEB008CA611 /* Milk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Milk.swift; sourceTree = "<group>"; };
+		E4E22D1D25E5EC53008CA611 /* SoftDrink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoftDrink.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -65,6 +67,7 @@
 				E4E22CE325E51B27008CA611 /* ViewController.swift */,
 				E4E22CF525E51E11008CA611 /* Beverage.swift */,
 				E4E22D1A25E5EAEB008CA611 /* Milk.swift */,
+				E4E22D1D25E5EC53008CA611 /* SoftDrink.swift */,
 				E4E22CE525E51B27008CA611 /* Main.storyboard */,
 				E4E22CE825E51B28008CA611 /* Assets.xcassets */,
 				E4E22CEA25E51B28008CA611 /* LaunchScreen.storyboard */,
@@ -147,6 +150,7 @@
 				E4E22CE025E51B27008CA611 /* AppDelegate.swift in Sources */,
 				E4E22CF625E51E11008CA611 /* Beverage.swift in Sources */,
 				E4E22CE225E51B27008CA611 /* SceneDelegate.swift in Sources */,
+				E4E22D1E25E5EC53008CA611 /* SoftDrink.swift in Sources */,
 				E4E22D1B25E5EAEB008CA611 /* Milk.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
+++ b/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		E4D472A725E5ED65007FAAA0 /* VendingMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D472A625E5ED65007FAAA0 /* VendingMachine.swift */; };
+		E4D472AA25E5F15E007FAAA0 /* OutputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D472A925E5F15E007FAAA0 /* OutputView.swift */; };
 		E4E22CE025E51B27008CA611 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E22CDF25E51B27008CA611 /* AppDelegate.swift */; };
 		E4E22CE225E51B27008CA611 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E22CE125E51B27008CA611 /* SceneDelegate.swift */; };
 		E4E22CE425E51B27008CA611 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E22CE325E51B27008CA611 /* ViewController.swift */; };
@@ -22,6 +23,7 @@
 
 /* Begin PBXFileReference section */
 		E4D472A625E5ED65007FAAA0 /* VendingMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VendingMachine.swift; sourceTree = "<group>"; };
+		E4D472A925E5F15E007FAAA0 /* OutputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutputView.swift; sourceTree = "<group>"; };
 		E4E22CDC25E51B27008CA611 /* VendingMachineApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = VendingMachineApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E4E22CDF25E51B27008CA611 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E4E22CE125E51B27008CA611 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -74,6 +76,7 @@
 				E4E22D1D25E5EC53008CA611 /* SoftDrink.swift */,
 				E4E22D2025E5ECC6008CA611 /* Coffee.swift */,
 				E4D472A625E5ED65007FAAA0 /* VendingMachine.swift */,
+				E4D472A925E5F15E007FAAA0 /* OutputView.swift */,
 				E4E22CE525E51B27008CA611 /* Main.storyboard */,
 				E4E22CE825E51B28008CA611 /* Assets.xcassets */,
 				E4E22CEA25E51B28008CA611 /* LaunchScreen.storyboard */,
@@ -160,6 +163,7 @@
 				E4E22D1B25E5EAEB008CA611 /* Milk.swift in Sources */,
 				E4E22D2125E5ECC6008CA611 /* Coffee.swift in Sources */,
 				E4D472A725E5ED65007FAAA0 /* VendingMachine.swift in Sources */,
+				E4D472AA25E5F15E007FAAA0 /* OutputView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
+++ b/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
@@ -1,0 +1,346 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		E4E22CE025E51B27008CA611 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E22CDF25E51B27008CA611 /* AppDelegate.swift */; };
+		E4E22CE225E51B27008CA611 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E22CE125E51B27008CA611 /* SceneDelegate.swift */; };
+		E4E22CE425E51B27008CA611 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E22CE325E51B27008CA611 /* ViewController.swift */; };
+		E4E22CE725E51B27008CA611 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E4E22CE525E51B27008CA611 /* Main.storyboard */; };
+		E4E22CE925E51B28008CA611 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E4E22CE825E51B28008CA611 /* Assets.xcassets */; };
+		E4E22CEC25E51B28008CA611 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E4E22CEA25E51B28008CA611 /* LaunchScreen.storyboard */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		E4E22CDC25E51B27008CA611 /* VendingMachineApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = VendingMachineApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		E4E22CDF25E51B27008CA611 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		E4E22CE125E51B27008CA611 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		E4E22CE325E51B27008CA611 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		E4E22CE625E51B27008CA611 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		E4E22CE825E51B28008CA611 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		E4E22CEB25E51B28008CA611 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		E4E22CED25E51B28008CA611 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		E4E22CD925E51B27008CA611 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		E4E22CD325E51B27008CA611 = {
+			isa = PBXGroup;
+			children = (
+				E4E22CDE25E51B27008CA611 /* VendingMachineApp */,
+				E4E22CDD25E51B27008CA611 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		E4E22CDD25E51B27008CA611 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				E4E22CDC25E51B27008CA611 /* VendingMachineApp.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		E4E22CDE25E51B27008CA611 /* VendingMachineApp */ = {
+			isa = PBXGroup;
+			children = (
+				E4E22CDF25E51B27008CA611 /* AppDelegate.swift */,
+				E4E22CE125E51B27008CA611 /* SceneDelegate.swift */,
+				E4E22CE325E51B27008CA611 /* ViewController.swift */,
+				E4E22CE525E51B27008CA611 /* Main.storyboard */,
+				E4E22CE825E51B28008CA611 /* Assets.xcassets */,
+				E4E22CEA25E51B28008CA611 /* LaunchScreen.storyboard */,
+				E4E22CED25E51B28008CA611 /* Info.plist */,
+			);
+			path = VendingMachineApp;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		E4E22CDB25E51B27008CA611 /* VendingMachineApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E4E22CF025E51B28008CA611 /* Build configuration list for PBXNativeTarget "VendingMachineApp" */;
+			buildPhases = (
+				E4E22CD825E51B27008CA611 /* Sources */,
+				E4E22CD925E51B27008CA611 /* Frameworks */,
+				E4E22CDA25E51B27008CA611 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = VendingMachineApp;
+			productName = VendingMachineApp;
+			productReference = E4E22CDC25E51B27008CA611 /* VendingMachineApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		E4E22CD425E51B27008CA611 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1240;
+				LastUpgradeCheck = 1240;
+				TargetAttributes = {
+					E4E22CDB25E51B27008CA611 = {
+						CreatedOnToolsVersion = 12.4;
+					};
+				};
+			};
+			buildConfigurationList = E4E22CD725E51B27008CA611 /* Build configuration list for PBXProject "VendingMachineApp" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = E4E22CD325E51B27008CA611;
+			productRefGroup = E4E22CDD25E51B27008CA611 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				E4E22CDB25E51B27008CA611 /* VendingMachineApp */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		E4E22CDA25E51B27008CA611 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E4E22CEC25E51B28008CA611 /* LaunchScreen.storyboard in Resources */,
+				E4E22CE925E51B28008CA611 /* Assets.xcassets in Resources */,
+				E4E22CE725E51B27008CA611 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		E4E22CD825E51B27008CA611 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E4E22CE425E51B27008CA611 /* ViewController.swift in Sources */,
+				E4E22CE025E51B27008CA611 /* AppDelegate.swift in Sources */,
+				E4E22CE225E51B27008CA611 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		E4E22CE525E51B27008CA611 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				E4E22CE625E51B27008CA611 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		E4E22CEA25E51B28008CA611 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				E4E22CEB25E51B28008CA611 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		E4E22CEE25E51B28008CA611 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		E4E22CEF25E51B28008CA611 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		E4E22CF125E51B28008CA611 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 5M27T5LV4H;
+				INFOPLIST_FILE = VendingMachineApp/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.song.VendingMachineApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		E4E22CF225E51B28008CA611 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 5M27T5LV4H;
+				INFOPLIST_FILE = VendingMachineApp/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.song.VendingMachineApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		E4E22CD725E51B27008CA611 /* Build configuration list for PBXProject "VendingMachineApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E4E22CEE25E51B28008CA611 /* Debug */,
+				E4E22CEF25E51B28008CA611 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E4E22CF025E51B28008CA611 /* Build configuration list for PBXNativeTarget "VendingMachineApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E4E22CF125E51B28008CA611 /* Debug */,
+				E4E22CF225E51B28008CA611 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = E4E22CD425E51B27008CA611 /* Project object */;
+}

--- a/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
+++ b/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		E4D472A725E5ED65007FAAA0 /* VendingMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D472A625E5ED65007FAAA0 /* VendingMachine.swift */; };
 		E4D472AA25E5F15E007FAAA0 /* OutputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D472A925E5F15E007FAAA0 /* OutputView.swift */; };
+		E4D472AD25E5F5B2007FAAA0 /* DateUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D472AC25E5F5B2007FAAA0 /* DateUtility.swift */; };
 		E4E22CE025E51B27008CA611 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E22CDF25E51B27008CA611 /* AppDelegate.swift */; };
 		E4E22CE225E51B27008CA611 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E22CE125E51B27008CA611 /* SceneDelegate.swift */; };
 		E4E22CE425E51B27008CA611 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E22CE325E51B27008CA611 /* ViewController.swift */; };
@@ -24,6 +25,7 @@
 /* Begin PBXFileReference section */
 		E4D472A625E5ED65007FAAA0 /* VendingMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VendingMachine.swift; sourceTree = "<group>"; };
 		E4D472A925E5F15E007FAAA0 /* OutputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutputView.swift; sourceTree = "<group>"; };
+		E4D472AC25E5F5B2007FAAA0 /* DateUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateUtility.swift; sourceTree = "<group>"; };
 		E4E22CDC25E51B27008CA611 /* VendingMachineApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = VendingMachineApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E4E22CDF25E51B27008CA611 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E4E22CE125E51B27008CA611 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -77,6 +79,7 @@
 				E4E22D2025E5ECC6008CA611 /* Coffee.swift */,
 				E4D472A625E5ED65007FAAA0 /* VendingMachine.swift */,
 				E4D472A925E5F15E007FAAA0 /* OutputView.swift */,
+				E4D472AC25E5F5B2007FAAA0 /* DateUtility.swift */,
 				E4E22CE525E51B27008CA611 /* Main.storyboard */,
 				E4E22CE825E51B28008CA611 /* Assets.xcassets */,
 				E4E22CEA25E51B28008CA611 /* LaunchScreen.storyboard */,
@@ -155,6 +158,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E4D472AD25E5F5B2007FAAA0 /* DateUtility.swift in Sources */,
 				E4E22CE425E51B27008CA611 /* ViewController.swift in Sources */,
 				E4E22CE025E51B27008CA611 /* AppDelegate.swift in Sources */,
 				E4E22CF625E51E11008CA611 /* Beverage.swift in Sources */,

--- a/VendingMachineApp/VendingMachineApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/VendingMachineApp/VendingMachineApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/VendingMachineApp/VendingMachineApp.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/VendingMachineApp/VendingMachineApp.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/VendingMachineApp/VendingMachineApp/AppDelegate.swift
+++ b/VendingMachineApp/VendingMachineApp/AppDelegate.swift
@@ -10,27 +10,5 @@ import UIKit
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-
-
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
-        return true
-    }
-
-    // MARK: UISceneSession Lifecycle
-
-    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
-        // Called when a new scene session is being created.
-        // Use this method to select a configuration to create the new scene with.
-        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
-    }
-
-    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
-        // Called when the user discards a scene session.
-        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
-        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
-    }
-
-
 }
 

--- a/VendingMachineApp/VendingMachineApp/AppDelegate.swift
+++ b/VendingMachineApp/VendingMachineApp/AppDelegate.swift
@@ -1,0 +1,36 @@
+//
+//  AppDelegate.swift
+//  VendingMachineApp
+//
+//  Created by Song on 2021/02/23.
+//
+
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+
+
+}
+

--- a/VendingMachineApp/VendingMachineApp/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/VendingMachineApp/VendingMachineApp/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/VendingMachineApp/VendingMachineApp/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/VendingMachineApp/VendingMachineApp/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/VendingMachineApp/VendingMachineApp/Assets.xcassets/Contents.json
+++ b/VendingMachineApp/VendingMachineApp/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/VendingMachineApp/VendingMachineApp/Base.lproj/LaunchScreen.storyboard
+++ b/VendingMachineApp/VendingMachineApp/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/VendingMachineApp/VendingMachineApp/Base.lproj/Main.storyboard
+++ b/VendingMachineApp/VendingMachineApp/Base.lproj/Main.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/VendingMachineApp/VendingMachineApp/Beverage.swift
+++ b/VendingMachineApp/VendingMachineApp/Beverage.swift
@@ -7,13 +7,16 @@
 
 import Foundation
 
-class Beverage {
+class Beverage: CustomStringConvertible {
     
     private let brand: String
     private let volume: Int
     private let price: Int
     private let name: String
     private let manufactureDate: Date
+    var description: String {
+        return "\(brand), \(volume)ml, \(price)원, \(name), \(DateUtility.getString(from: manufactureDate))"
+    }
     
     init(brand: String, volume: Int, price: Int, name: String, manufactureDate: String) throws {
         self.brand = brand

--- a/VendingMachineApp/VendingMachineApp/Beverage.swift
+++ b/VendingMachineApp/VendingMachineApp/Beverage.swift
@@ -15,11 +15,11 @@ class Beverage {
     private let name: String
     private let manufactureDate: Date
     
-    init(brand: String, volume: Int, price: Int, name: String, manufactureDate: Date) {
+    init(brand: String, volume: Int, price: Int, name: String, manufactureDate: String) throws {
         self.brand = brand
         self.volume = volume
         self.price = price
         self.name = name
-        self.manufactureDate = manufactureDate
+        self.manufactureDate = try DateUtility.getDate(from: manufactureDate)
     }
 }

--- a/VendingMachineApp/VendingMachineApp/Beverage.swift
+++ b/VendingMachineApp/VendingMachineApp/Beverage.swift
@@ -9,4 +9,17 @@ import Foundation
 
 class Beverage {
     
+    private let brand: String
+    private let volume: Int
+    private let price: Int
+    private let name: String
+    private let manufactureDate: Date
+    
+    init(brand: String, volume: Int, price: Int, name: String, manufactureDate: Date) {
+        self.brand = brand
+        self.volume = volume
+        self.price = price
+        self.name = name
+        self.manufactureDate = manufactureDate
+    }
 }

--- a/VendingMachineApp/VendingMachineApp/Beverage.swift
+++ b/VendingMachineApp/VendingMachineApp/Beverage.swift
@@ -1,0 +1,12 @@
+//
+//  Beverage.swift
+//  VendingMachineApp
+//
+//  Created by Song on 2021/02/23.
+//
+
+import Foundation
+
+class Beverage {
+    
+}

--- a/VendingMachineApp/VendingMachineApp/Coffee.swift
+++ b/VendingMachineApp/VendingMachineApp/Coffee.swift
@@ -17,8 +17,8 @@ class Coffee: Beverage {
     
     private let type: CoffeeType
     
-    init(brand: String, volume: Int, price: Int, name: String, manufactureDate: Date, type: CoffeeType) {
+    init(brand: String, volume: Int, price: Int, name: String, manufactureDate: String, type: CoffeeType) throws {
         self.type = type
-        super.init(brand: brand, volume: volume, price: price, name: name, manufactureDate: manufactureDate)
+        try super.init(brand: brand, volume: volume, price: price, name: name, manufactureDate: manufactureDate)
     }
 }

--- a/VendingMachineApp/VendingMachineApp/Coffee.swift
+++ b/VendingMachineApp/VendingMachineApp/Coffee.swift
@@ -1,0 +1,24 @@
+//
+//  Coffee.swift
+//  VendingMachineApp
+//
+//  Created by Song on 2021/02/24.
+//
+
+import Foundation
+
+class Coffee: Beverage {
+    
+    enum CoffeeType {
+        case top
+        case cantata
+        case georgia
+    }
+    
+    private let type: CoffeeType
+    
+    init(brand: String, volume: Int, price: Int, name: String, manufactureDate: Date, type: CoffeeType) {
+        self.type = type
+        super.init(brand: brand, volume: volume, price: price, name: name, manufactureDate: manufactureDate)
+    }
+}

--- a/VendingMachineApp/VendingMachineApp/DateUtility.swift
+++ b/VendingMachineApp/VendingMachineApp/DateUtility.swift
@@ -1,0 +1,31 @@
+//
+//  DateUtility.swift
+//  VendingMachineApp
+//
+//  Created by Song on 2021/02/24.
+//
+
+import Foundation
+
+enum DateError: Error {
+    case invalidInputFormat(validFormat: String)
+}
+
+struct DateUtility {
+    
+    static private let dateFormatter = DateFormatter()
+    static private let validFormat: String = "yyyyMMdd"
+    
+    static func getString(from date: Date) -> String {
+        dateFormatter.dateFormat = validFormat
+        return dateFormatter.string(from: date)
+    }
+    
+    static func getDate(from dateString: String) throws -> Date {
+        dateFormatter.dateFormat = validFormat
+        guard let date = dateFormatter.date(from: dateString) else {
+            throw DateError.invalidInputFormat(validFormat: validFormat)
+        }
+        return date
+    }
+}

--- a/VendingMachineApp/VendingMachineApp/Info.plist
+++ b/VendingMachineApp/VendingMachineApp/Info.plist
@@ -51,7 +51,6 @@
 	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
-		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>

--- a/VendingMachineApp/VendingMachineApp/Info.plist
+++ b/VendingMachineApp/VendingMachineApp/Info.plist
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/VendingMachineApp/VendingMachineApp/Milk.swift
+++ b/VendingMachineApp/VendingMachineApp/Milk.swift
@@ -17,8 +17,8 @@ class Milk: Beverage {
     
     private let type: MilkType
     
-    init(brand: String, volume: Int, price: Int, name: String, manufactureDate: Date, type: MilkType) {
+    init(brand: String, volume: Int, price: Int, name: String, manufactureDate: String, type: MilkType) throws {
         self.type = type
-        super.init(brand: brand, volume: volume, price: price, name: name, manufactureDate: manufactureDate)
+        try super.init(brand: brand, volume: volume, price: price, name: name, manufactureDate: manufactureDate)
     }
 }

--- a/VendingMachineApp/VendingMachineApp/Milk.swift
+++ b/VendingMachineApp/VendingMachineApp/Milk.swift
@@ -1,0 +1,24 @@
+//
+//  Milk.swift
+//  VendingMachineApp
+//
+//  Created by Song on 2021/02/24.
+//
+
+import Foundation
+
+class Milk: Beverage {
+    
+    enum MilkType {
+        case strawberry
+        case chocolate
+        case banana
+    }
+    
+    private let type: MilkType
+    
+    init(brand: String, volume: Int, price: Int, name: String, manufactureDate: Date, type: MilkType) {
+        self.type = type
+        super.init(brand: brand, volume: volume, price: price, name: name, manufactureDate: manufactureDate)
+    }
+}

--- a/VendingMachineApp/VendingMachineApp/OutputView.swift
+++ b/VendingMachineApp/VendingMachineApp/OutputView.swift
@@ -1,0 +1,20 @@
+//
+//  OutputView.swift
+//  VendingMachineApp
+//
+//  Created by Song on 2021/02/24.
+//
+
+import Foundation
+
+protocol OutputViewPrintable {
+    func printBeverage(handler: (Beverage) -> ())
+}
+
+struct OutputView {
+    static func printInventory(of vendingMachine: OutputViewPrintable) {
+        vendingMachine.printBeverage {
+            print($0)
+        }
+    }
+}

--- a/VendingMachineApp/VendingMachineApp/SceneDelegate.swift
+++ b/VendingMachineApp/VendingMachineApp/SceneDelegate.swift
@@ -11,42 +11,5 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
 
-
-    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
-        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
-        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
-        guard let _ = (scene as? UIWindowScene) else { return }
-    }
-
-    func sceneDidDisconnect(_ scene: UIScene) {
-        // Called as the scene is being released by the system.
-        // This occurs shortly after the scene enters the background, or when its session is discarded.
-        // Release any resources associated with this scene that can be re-created the next time the scene connects.
-        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
-    }
-
-    func sceneDidBecomeActive(_ scene: UIScene) {
-        // Called when the scene has moved from an inactive state to an active state.
-        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
-    }
-
-    func sceneWillResignActive(_ scene: UIScene) {
-        // Called when the scene will move from an active state to an inactive state.
-        // This may occur due to temporary interruptions (ex. an incoming phone call).
-    }
-
-    func sceneWillEnterForeground(_ scene: UIScene) {
-        // Called as the scene transitions from the background to the foreground.
-        // Use this method to undo the changes made on entering the background.
-    }
-
-    func sceneDidEnterBackground(_ scene: UIScene) {
-        // Called as the scene transitions from the foreground to the background.
-        // Use this method to save data, release shared resources, and store enough scene-specific state information
-        // to restore the scene back to its current state.
-    }
-
-
 }
 

--- a/VendingMachineApp/VendingMachineApp/SceneDelegate.swift
+++ b/VendingMachineApp/VendingMachineApp/SceneDelegate.swift
@@ -1,0 +1,52 @@
+//
+//  SceneDelegate.swift
+//  VendingMachineApp
+//
+//  Created by Song on 2021/02/23.
+//
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        guard let _ = (scene as? UIWindowScene) else { return }
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+    }
+
+
+}
+

--- a/VendingMachineApp/VendingMachineApp/SoftDrink.swift
+++ b/VendingMachineApp/VendingMachineApp/SoftDrink.swift
@@ -1,0 +1,24 @@
+//
+//  SoftDrink.swift
+//  VendingMachineApp
+//
+//  Created by Song on 2021/02/24.
+//
+
+import Foundation
+
+class SoftDrink: Beverage {
+    
+    enum SoftDrinkType {
+        case cola
+        case sprite
+        case fanta
+    }
+    
+    private let type: SoftDrinkType
+    
+    init(brand: String, volume: Int, price: Int, name: String, manufactureDate: Date, type: SoftDrinkType) {
+        self.type = type
+        super.init(brand: brand, volume: volume, price: price, name: name, manufactureDate: manufactureDate)
+    }
+}

--- a/VendingMachineApp/VendingMachineApp/SoftDrink.swift
+++ b/VendingMachineApp/VendingMachineApp/SoftDrink.swift
@@ -17,8 +17,8 @@ class SoftDrink: Beverage {
     
     private let type: SoftDrinkType
     
-    init(brand: String, volume: Int, price: Int, name: String, manufactureDate: Date, type: SoftDrinkType) {
+    init(brand: String, volume: Int, price: Int, name: String, manufactureDate: String, type: SoftDrinkType) throws {
         self.type = type
-        super.init(brand: brand, volume: volume, price: price, name: name, manufactureDate: manufactureDate)
+        try super.init(brand: brand, volume: volume, price: price, name: name, manufactureDate: manufactureDate)
     }
 }

--- a/VendingMachineApp/VendingMachineApp/VendingMachine.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine.swift
@@ -1,0 +1,16 @@
+//
+//  VendingMachine.swift
+//  VendingMachineApp
+//
+//  Created by Song on 2021/02/24.
+//
+
+import Foundation
+
+class VendingMachine {
+    private let inventory: [Beverage]
+    
+    init(inventory: [Beverage]) {
+        self.inventory = inventory
+    }
+}

--- a/VendingMachineApp/VendingMachineApp/VendingMachine.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine.swift
@@ -7,10 +7,17 @@
 
 import Foundation
 
-class VendingMachine {
+class VendingMachine: OutputViewPrintable {
+    
     private let inventory: [Beverage]
     
     init(inventory: [Beverage]) {
         self.inventory = inventory
+    }
+    
+    func printBeverage(handler: (Beverage) -> ()) {
+        inventory.forEach {
+            handler($0)
+        }
     }
 }

--- a/VendingMachineApp/VendingMachineApp/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/ViewController.swift
@@ -11,9 +11,16 @@ class ViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
+        
+        do {
+            let seoulStrawberryMilk1 = try Milk(brand: "서울우유", volume: 200, price: 1000, name: "날마다딸기우유", manufactureDate: "20171009", type: .strawberry)
+            let seoulStrawberryMilk2 = try Milk(brand: "서울우유", volume: 200, price: 1000, name: "날마다딸기우유", manufactureDate: "20171012", type: .strawberry)
+            let pepsiDietCola = try SoftDrink(brand: "팹시", volume: 350, price: 2000, name: "다이어트콜라", manufactureDate: "20171005", type: .cola)
+            let topAmericano = try Coffee(brand: "맥심", volume: 400, price: 3000, name: "TOP아메리카노", manufactureDate: "20171010", type: .top)
+        } catch DateError.invalidInputFormat(let validFormat) {
+            print("Invalid date string format, a valid format is: \(validFormat)")
+        } catch {
+            print("Unexpectd error: \(error)")
+        }
     }
-
-
 }
-

--- a/VendingMachineApp/VendingMachineApp/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/ViewController.swift
@@ -17,6 +17,9 @@ class ViewController: UIViewController {
             let seoulStrawberryMilk2 = try Milk(brand: "서울우유", volume: 200, price: 1000, name: "날마다딸기우유", manufactureDate: "20171012", type: .strawberry)
             let pepsiDietCola = try SoftDrink(brand: "팹시", volume: 350, price: 2000, name: "다이어트콜라", manufactureDate: "20171005", type: .cola)
             let topAmericano = try Coffee(brand: "맥심", volume: 400, price: 3000, name: "TOP아메리카노", manufactureDate: "20171010", type: .top)
+            
+            let vendingMachine = VendingMachine(inventory: [seoulStrawberryMilk1, seoulStrawberryMilk2, pepsiDietCola, topAmericano])
+            OutputView.printInventory(of: vendingMachine)
         } catch DateError.invalidInputFormat(let validFormat) {
             print("Invalid date string format, a valid format is: \(validFormat)")
         } catch {

--- a/VendingMachineApp/VendingMachineApp/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/ViewController.swift
@@ -1,0 +1,19 @@
+//
+//  ViewController.swift
+//  VendingMachineApp
+//
+//  Created by Song on 2021/02/23.
+//
+
+import UIKit
+
+class ViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view.
+    }
+
+
+}
+


### PR DESCRIPTION
### 스텝별 작업 목록
- [x] Deployment Info 설정
- [x] Superclass `Beverage` 생성
- [x] Subclass `Milk`, `SoftDrink`, `Coffee` 생성
- [x] 각 Subclass에 음료 타입을 Nested enum으로 구현
- [x] Date format 관련 업무를 처리하는 `DateUtility` struct 구현
- [x] 출력 관련 업무를 처리하는 `OutputView` struct와 `OutputViewPrintable` protocol을 통해 출력부를 분리
- [x] 음료 재고 관련 업무를 처리하는 `VendingMachine` class 구현

### 학습 키워드
* `UIApplicationMain(_:_:_:_:)`
  * UIApplication을 띄우는 함수
  * AppDelegate.swift의 `@main`에 포함됨
* HugeLadderGame 코드 학습 및 적용
  * 아직 앱 화면에 내용을 띄우는 단계가 아니라 HugeLadderGame 코드를 적용해보기 좋았습니다 :)

### 고민과 해결
* 상속 vs. Protocol
  * 음료의 경우 Protocol로 추상화하면 필수 속성 (브랜드, 용량, 가격, etc.)을 private으로 지정할 수 없어 `Beverage`라는 superclass를 만들고 상속하는 방식으로 구현했습니다.
  * HugeLadderGame 코드처럼 `OutputViewPrintable` protocol을 사용해 의존 관계를 끊는 연습을 해보았습니다.
* `DateUtility`
  * Date를 다루는 것은 이번 스텝에서 가장 어렵게 느껴진 부분이었습니다. 새로운 `Beverage` instance를 만들 때, 제조일자를 Date 타입으로 넘기려고 보니 오늘 날짜는 `Date()`로 간단히 구현이 가능하지만 다른 날짜는 경과한 시간을 초 기준으로 입력해주어야 해서 간단하지가 않았습니다.
  * Date를 좀 더 간단히 다루는 방법으로 `DateFormatter`와 `DateComponents`가 있다는 것을 알게 되었고 두 가지 중 첫 번째 `DateFormatter`를 선택해 `DateUtility`를 구현했습니다.
    * `DateComponents`의 경우, 필요한 항목만 선택해 입력한 후 `.date`를 뒤에 붙여주면 간편히 Date로 변환할 수 있다는 점이 좋았지만 instance를 생성하는 시점에서 코드가 길어진다는 단점이 있었습니다.
    * 그래서 `DateFormatter`를 통해서 init에서는 제조일자를 String으로 받아 Date로 변환, description에서는 내부 프로퍼티인 Date를 String으로 변환해 문자열로 사용할 수 있게 했습니다.
  * init 시, 날짜를 잘못된 형식으로 넘기는 경우를 처리해주기 위해 `DateError` enum을 정의하고 Error handling 해주었습니다.

### 질문거리
* Superclass인 `Beverage`가 5개의 내부 프로퍼티를 가지고 있다보니 init 시 입력해주어야 하는 매개변수가 많아 줄이 길어지는데 이후 Subclass들에 변수를 더 추가하게 되면 init은 어떻게 처리해주어야 하는 것일까 하는 고민이 들었습니다👀
  * 예시) `init(brand: String, volume: Int, price: Int, name: String, manufactureDate: String, type: MilkType)`