### PR TITLE
[쏭] Step4 & 5 - 객체 속성의 저장 및 복원

### DIFF
--- a/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
+++ b/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
@@ -570,7 +570,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.song.VendingMachineApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 2;
 			};
 			name = Debug;
 		};
@@ -589,7 +589,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.song.VendingMachineApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 2;
 			};
 			name = Release;
 		};

--- a/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
+++ b/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		E474526625FDFF6F007D894F /* InventorySheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = E474526525FDFF6F007D894F /* InventorySheet.swift */; };
 		E4A82DCF25F88F23001F03E1 /* String+ExtractingNumbers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A82DCE25F88F23001F03E1 /* String+ExtractingNumbers.swift */; };
 		E4D472A725E5ED65007FAAA0 /* VendingMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D472A625E5ED65007FAAA0 /* VendingMachine.swift */; };
 		E4D472B825E76C51007FAAA0 /* Date+DateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D472B725E76C51007FAAA0 /* Date+DateFormatter.swift */; };
@@ -64,6 +65,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		E474526525FDFF6F007D894F /* InventorySheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InventorySheet.swift; sourceTree = "<group>"; };
 		E4A82DCE25F88F23001F03E1 /* String+ExtractingNumbers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+ExtractingNumbers.swift"; sourceTree = "<group>"; };
 		E4D472A625E5ED65007FAAA0 /* VendingMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VendingMachine.swift; sourceTree = "<group>"; };
 		E4D472B725E76C51007FAAA0 /* Date+DateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+DateFormatter.swift"; sourceTree = "<group>"; };
@@ -161,6 +163,7 @@
 				E4D4743E25F5F746007FAAA0 /* CashBox.swift */,
 				E4D4734725EF8634007FAAA0 /* Slot.swift */,
 				E4D4734A25EF8651007FAAA0 /* Inventory.swift */,
+				E474526525FDFF6F007D894F /* InventorySheet.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -355,6 +358,7 @@
 				E4E22CF625E51E11008CA611 /* Beverage.swift in Sources */,
 				E4D473B925F0ADF3007FAAA0 /* PurchaseHistory.swift in Sources */,
 				E4D4743F25F5F746007FAAA0 /* CashBox.swift in Sources */,
+				E474526625FDFF6F007D894F /* InventorySheet.swift in Sources */,
 				E4E22CE225E51B27008CA611 /* SceneDelegate.swift in Sources */,
 				E4E22D1E25E5EC53008CA611 /* SoftDrink.swift in Sources */,
 				E4E22D1B25E5EAEB008CA611 /* Milk.swift in Sources */,

--- a/VendingMachineApp/VendingMachineApp/AppDelegate.swift
+++ b/VendingMachineApp/VendingMachineApp/AppDelegate.swift
@@ -9,6 +9,6 @@ import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
+    var vendingMachine: VendingMachine!
 }
 

--- a/VendingMachineApp/VendingMachineApp/AppDelegate.swift
+++ b/VendingMachineApp/VendingMachineApp/AppDelegate.swift
@@ -9,6 +9,5 @@ import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-    var vendingMachine: VendingMachine!
+    
 }
-

--- a/VendingMachineApp/VendingMachineApp/Controllers/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/Controllers/ViewController.swift
@@ -22,10 +22,7 @@ class ViewController: UIViewController {
         
         configureSubscriber()
         initialSetupVendingMachine()
-    }
-    
-    @objc func itemQuantityIncrementButtonPressed(_ sender: UIButton) {
-        configureInventory(sender)
+        configureInventory()
     }
     
     @IBAction func insertMoneyButtonPressed(_ sender: UIButton) {
@@ -50,12 +47,17 @@ class ViewController: UIViewController {
             }
     }
     
-    private func configureInventory(_ sender: UIButton) {
-        let selectedSlotView = sender.superview?.superview as? SlotView
-        let slotInfo = inventoryInfo.filter { selectedSlotView == $0.value }.first
-        /// 현 단계에서는 재고 정보(제조일자, 유통기한 등)를 입력할 수 있는 란이 따로 없어 슬롯의 첫번째 상품과 동일한 상품의 재고를 추가하도록 구현
-        if let item = slotInfo?.key.firstItem {
-            vendingMachine.add(item: item)
+    private func configureInventory() {
+        NotificationCenter.default.addObserver(self, selector: #selector(itemQuantityIncrementButtonPressed(_:)), name: SlotView.Notification.DidButtonPressed, object: nil)
+    }
+    
+    @objc func itemQuantityIncrementButtonPressed(_ notification: Notification) {
+        if let selectedSlotView = (notification.userInfo as? [String : SlotView])?.first {
+            let slotInfo = inventoryInfo.filter { selectedSlotView.value == $0.value }.first
+            /// 현 단계에서는 재고 정보(제조일자, 유통기한 등)를 입력할 수 있는 란이 따로 없어 슬롯의 첫번째 상품과 동일한 상품의 재고를 추가하도록 구현
+            if let item = slotInfo?.key.firstItem {
+                vendingMachine.add(item: item)
+            }
         }
     }
     
@@ -81,7 +83,6 @@ class ViewController: UIViewController {
         
         inventorySheet.forEach { inventory in
             let slotView = makeSlotView(with: inventory.key)
-            slotView.itemQuantityIncrementButton.addTarget(self, action: #selector(itemQuantityIncrementButtonPressed(_:)), for: .touchUpInside)
             self.inventoryStackView.addArrangedSubview(slotView)
             inventoryInfo[inventory.key] = slotView
         }

--- a/VendingMachineApp/VendingMachineApp/Controllers/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/Controllers/ViewController.swift
@@ -22,7 +22,6 @@ class ViewController: UIViewController {
         super.viewDidLoad()
         
         configureSubscriber()
-        initialSetupVendingMachine()
         configureInventory()
     }
     

--- a/VendingMachineApp/VendingMachineApp/Controllers/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/Controllers/ViewController.swift
@@ -12,8 +12,8 @@ class ViewController: UIViewController {
     @IBOutlet weak var inventoryStackView: UIStackView!
     @IBOutlet weak var balanceLabel: UILabel!
     
-    private var vendingMachine: VendingMachine!
     private var inventoryInfo: [Slot: SlotView] = [ : ]
+    private let appDelegate = UIApplication.shared.delegate as? AppDelegate
     private var inventoryPublisher: AnyCancellable!
     private var cashBoxPublisher: AnyCancellable!
     
@@ -56,21 +56,21 @@ class ViewController: UIViewController {
             let slotInfo = inventoryInfo.filter { selectedSlotView.value == $0.value }.first
             /// 현 단계에서는 재고 정보(제조일자, 유통기한 등)를 입력할 수 있는 란이 따로 없어 슬롯의 첫번째 상품과 동일한 상품의 재고를 추가하도록 구현
             if let item = slotInfo?.key.firstItem {
-                vendingMachine.add(item: item)
+                appDelegate?.vendingMachine.add(item: item)
             }
         }
     }
     
     private func configureCashBox(_ sender: UIButton) {
         guard let selectedAmount = Int(sender.titleLabel?.text?.filterNonDigits() ?? "0") else { return }
-        vendingMachine.insertMoney(amount: selectedAmount)
+        appDelegate?.vendingMachine.insertMoney(amount: selectedAmount)
     }
     
     private func initialSetupVendingMachine() {
-        self.vendingMachine = VendingMachine(numberOfSlots: 5)
+        appDelegate?.vendingMachine = VendingMachine(numberOfSlots: 5)
         let beverageFactoryList: [BeverageFactory] = [DenmarkStrawberryMilkFactory(), MaeilChocolateMilkFactory(), ZeroSugarCokeFactory(), GeorgiaMaxFactory(), RedBullFactory()]
         beverageFactoryList.forEach { factory in
-            vendingMachine.bulkInsert(itemFrom: factory, quantity: 5, manufactured: Date().formattedDate(from: "20210222"), expiredAfter: Date().formattedDate(from: "20210302"))
+            appDelegate?.vendingMachine.bulkInsert(itemFrom: factory, quantity: 5, manufactured: Date().formattedDate(from: "20210222"), expiredAfter: Date().formattedDate(from: "20210302"))
         }
     }
     
@@ -79,9 +79,9 @@ class ViewController: UIViewController {
             subview.removeFromSuperview()
         }
         inventoryInfo = [ : ]
-        let inventorySheet = vendingMachine.takeInventory().sorted { $0.key.description < $1.key.description }
+        let inventorySheet = appDelegate?.vendingMachine.takeInventory().sorted { $0.key.description < $1.key.description }
         
-        inventorySheet.forEach { inventory in
+        inventorySheet?.forEach { inventory in
             let slotView = makeSlotView(with: inventory.key)
             self.inventoryStackView.addArrangedSubview(slotView)
             inventoryInfo[inventory.key] = slotView
@@ -89,7 +89,7 @@ class ViewController: UIViewController {
     }
     
     private func configureCashBoxView() {
-        balanceLabel.text = "잔액 : \(vendingMachine.showBalance())원"
+        balanceLabel.text = "잔액 : \(appDelegate?.vendingMachine.showBalance() ?? 0)원"
     }
     
     private func makeSlotView(with slot: Slot) -> SlotView {

--- a/VendingMachineApp/VendingMachineApp/Controllers/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/Controllers/ViewController.swift
@@ -13,7 +13,8 @@ class ViewController: UIViewController {
     @IBOutlet weak var balanceLabel: UILabel!
     
     private var inventoryInfo: [Slot: SlotView] = [ : ]
-    private let appDelegate = UIApplication.shared.delegate as? AppDelegate
+    private let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+    private lazy var sceneDelegate = windowScene?.delegate as? SceneDelegate
     private var inventoryPublisher: AnyCancellable!
     private var cashBoxPublisher: AnyCancellable!
     
@@ -56,22 +57,14 @@ class ViewController: UIViewController {
             let slotInfo = inventoryInfo.filter { selectedSlotView.value == $0.value }.first
             /// 현 단계에서는 재고 정보(제조일자, 유통기한 등)를 입력할 수 있는 란이 따로 없어 슬롯의 첫번째 상품과 동일한 상품의 재고를 추가하도록 구현
             if let item = slotInfo?.key.firstItem {
-                appDelegate?.vendingMachine.add(item: item)
+                sceneDelegate?.vendingMachine.add(item: item)
             }
         }
     }
     
     private func configureCashBox(_ sender: UIButton) {
         guard let selectedAmount = Int(sender.titleLabel?.text?.filterNonDigits() ?? "0") else { return }
-        appDelegate?.vendingMachine.insertMoney(amount: selectedAmount)
-    }
-    
-    private func initialSetupVendingMachine() {
-        appDelegate?.vendingMachine = VendingMachine(numberOfSlots: 5)
-        let beverageFactoryList: [BeverageFactory] = [DenmarkStrawberryMilkFactory(), MaeilChocolateMilkFactory(), ZeroSugarCokeFactory(), GeorgiaMaxFactory(), RedBullFactory()]
-        beverageFactoryList.forEach { factory in
-            appDelegate?.vendingMachine.bulkInsert(itemFrom: factory, quantity: 5, manufactured: Date().formattedDate(from: "20210222"), expiredAfter: Date().formattedDate(from: "20210302"))
-        }
+        sceneDelegate?.vendingMachine.insertMoney(amount: selectedAmount)
     }
     
     private func configureInventoryView() {
@@ -79,7 +72,7 @@ class ViewController: UIViewController {
             subview.removeFromSuperview()
         }
         inventoryInfo = [ : ]
-        let inventorySheet = appDelegate?.vendingMachine.takeInventory().sorted { $0.key.description < $1.key.description }
+        let inventorySheet = sceneDelegate?.vendingMachine.takeInventory().sorted { $0.key.description < $1.key.description }
         
         inventorySheet?.forEach { inventory in
             let slotView = makeSlotView(with: inventory.key)
@@ -89,7 +82,7 @@ class ViewController: UIViewController {
     }
     
     private func configureCashBoxView() {
-        balanceLabel.text = "잔액 : \(appDelegate?.vendingMachine.showBalance() ?? 0)원"
+        balanceLabel.text = "잔액 : \(sceneDelegate?.vendingMachine.showBalance() ?? 0)원"
     }
     
     private func makeSlotView(with slot: Slot) -> SlotView {

--- a/VendingMachineApp/VendingMachineApp/Controllers/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/Controllers/ViewController.swift
@@ -60,9 +60,8 @@ class ViewController: UIViewController {
     }
     
     private func configureCashBox(_ sender: UIButton) {
-        if let selectedAmount = Int(sender.titleLabel?.text?.filterNonDigits() ?? "0") {
-            vendingMachine.insertMoney(amount: selectedAmount)
-        }
+        guard let selectedAmount = Int(sender.titleLabel?.text?.filterNonDigits() ?? "0") else { return }
+        vendingMachine.insertMoney(amount: selectedAmount)
     }
     
     private func initialSetupVendingMachine() {

--- a/VendingMachineApp/VendingMachineApp/Controllers/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/Controllers/ViewController.swift
@@ -18,6 +18,13 @@ class ViewController: UIViewController {
     private var inventoryPublisher: AnyCancellable!
     private var cashBoxPublisher: AnyCancellable!
     
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        configureInventoryView()
+        configureCashBoxView()
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         

--- a/VendingMachineApp/VendingMachineApp/Controllers/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/Controllers/ViewController.swift
@@ -67,11 +67,10 @@ class ViewController: UIViewController {
     
     private func initialSetupVendingMachine() {
         self.vendingMachine = VendingMachine(numberOfSlots: 5)
-        vendingMachine.bulkInsert(itemFrom: DenmarkStrawberryMilkFactory(), quantity: 5, manufactured: Date().formattedDate(from: "20210222"), expiredAfter: Date().formattedDate(from: "20210302"))
-        vendingMachine.bulkInsert(itemFrom: MaeilChocolateMilkFactory(), quantity: 5, manufactured: Date().formattedDate(from: "20210222"), expiredAfter: Date().formattedDate(from: "20210302"))
-        vendingMachine.bulkInsert(itemFrom: ZeroSugarCokeFactory(), quantity: 5, manufactured: Date().formattedDate(from: "20210222"), expiredAfter: Date().formattedDate(from: "20210302"))
-        vendingMachine.bulkInsert(itemFrom: GeorgiaMaxFactory(), quantity: 5, manufactured: Date().formattedDate(from: "20210222"), expiredAfter: Date().formattedDate(from: "20210302"))
-        vendingMachine.bulkInsert(itemFrom: RedBullFactory(), quantity: 5, manufactured: Date().formattedDate(from: "20210222"), expiredAfter: Date().formattedDate(from: "20210302"))
+        let beverageFactoryList: [BeverageFactory] = [DenmarkStrawberryMilkFactory(), MaeilChocolateMilkFactory(), ZeroSugarCokeFactory(), GeorgiaMaxFactory(), RedBullFactory()]
+        beverageFactoryList.forEach { factory in
+            vendingMachine.bulkInsert(itemFrom: factory, quantity: 5, manufactured: Date().formattedDate(from: "20210222"), expiredAfter: Date().formattedDate(from: "20210302"))
+        }
     }
     
     private func configureInventoryView() {

--- a/VendingMachineApp/VendingMachineApp/Info.plist
+++ b/VendingMachineApp/VendingMachineApp/Info.plist
@@ -56,8 +56,6 @@
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
-		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>

--- a/VendingMachineApp/VendingMachineApp/Models/Beverage.swift
+++ b/VendingMachineApp/VendingMachineApp/Models/Beverage.swift
@@ -40,12 +40,12 @@ class Beverage: NSObject, NSCoding, SafelyDrinkable {
     }
     
     required init?(coder: NSCoder) {
-        self.brand = coder.decodeObject(forKey: "brand") as? String ?? ""
+        self.brand = coder.decodeObject(forKey: "brand") as! String
         self.volume = coder.decodeInteger(forKey: "volume")
         self.price = coder.decodeInteger(forKey: "price")
-        self.name = coder.decodeObject(forKey: "name") as? String ?? ""
+        self.name = coder.decodeObject(forKey: "name") as! String
         self.calorie = coder.decodeInteger(forKey: "calorie")
-        self.imageName = coder.decodeObject(forKey: "imageName") as? String ?? ""
+        self.imageName = coder.decodeObject(forKey: "imageName") as! String
         self.manufactured = coder.decodeObject(forKey: "manufactured") as! Date?
         self.expiredAfter = coder.decodeObject(forKey: "expiredAfter") as! Date?
     }

--- a/VendingMachineApp/VendingMachineApp/Models/Beverage.swift
+++ b/VendingMachineApp/VendingMachineApp/Models/Beverage.swift
@@ -7,12 +7,7 @@
 
 import Foundation
 
-class Beverage: CustomStringConvertible, Hashable, SafelyDrinkable {
-    
-    static func == (lhs: Beverage, rhs: Beverage) -> Bool {
-        return lhs.brand == rhs.brand && lhs.volume == rhs.volume && lhs.price == rhs.price && lhs.name == rhs.name && lhs.calorie == rhs.calorie && lhs.manufactured == rhs.manufactured && lhs.expiredAfter == rhs.expiredAfter
-    }
-    
+class Beverage: NSObject, NSCoding, SafelyDrinkable {
     private(set) var brand: String
     private(set) var volume: Int
     private(set) var price: Int
@@ -21,9 +16,6 @@ class Beverage: CustomStringConvertible, Hashable, SafelyDrinkable {
     private(set) var imageName: String
     private let manufactured: Date?
     private let expiredAfter: Date?
-    var description: String {
-        return "\(brand), \(volume)ml, \(price)원, \(name), \(manufactured?.formattedString ?? "")"
-    }
     
     init(brand: String, volume: Int, price: Int, name: String, calorie: Int, imageName: String, manufactured: Date?, expiredAfter: Date?) {
         self.brand = brand
@@ -36,7 +28,35 @@ class Beverage: CustomStringConvertible, Hashable, SafelyDrinkable {
         self.expiredAfter = expiredAfter
     }
     
-    func hash(into hasher: inout Hasher) {
+    func encode(with coder: NSCoder) {
+        coder.encode(brand, forKey: "brand")
+        coder.encode(volume, forKey: "volume")
+        coder.encode(price, forKey: "price")
+        coder.encode(name, forKey: "name")
+        coder.encode(calorie, forKey: "calorie")
+        coder.encode(imageName, forKey: "imageName")
+        coder.encode(manufactured, forKey: "manufactured")
+        coder.encode(expiredAfter, forKey: "expiredAfter")
+    }
+    
+    required init?(coder: NSCoder) {
+        self.brand = coder.decodeObject(forKey: "brand") as? String ?? ""
+        self.volume = coder.decodeInteger(forKey: "volume")
+        self.price = coder.decodeInteger(forKey: "price")
+        self.name = coder.decodeObject(forKey: "name") as? String ?? ""
+        self.calorie = coder.decodeInteger(forKey: "calorie")
+        self.imageName = coder.decodeObject(forKey: "imageName") as? String ?? ""
+        self.manufactured = coder.decodeObject(forKey: "manufactured") as! Date?
+        self.expiredAfter = coder.decodeObject(forKey: "expiredAfter") as! Date?
+    }
+    
+    public override func isEqual(_ other: Any?) -> Bool {
+        guard let other = other as? Beverage else { return false }
+        return self.brand == other.brand && self.volume == other.volume && self.price == other.price && self.name == other.name && self.calorie == other.calorie && self.manufactured == other.manufactured && self.expiredAfter == other.expiredAfter
+    }
+    
+    public override var hash: Int {
+        var hasher = Hasher()
         hasher.combine(brand)
         hasher.combine(volume)
         hasher.combine(price)
@@ -45,6 +65,7 @@ class Beverage: CustomStringConvertible, Hashable, SafelyDrinkable {
         hasher.combine(imageName)
         hasher.combine(manufactured)
         hasher.combine(expiredAfter)
+        return hasher.finalize()
     }
     
     func isStillEdible(at date: Date) -> Bool {

--- a/VendingMachineApp/VendingMachineApp/Models/CashBox.swift
+++ b/VendingMachineApp/VendingMachineApp/Models/CashBox.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct CashBox {
+class CashBox: NSObject, NSCoding {
     private var totalRevenue: Int
     private var moneyDeposited: Int
     
@@ -16,11 +16,21 @@ struct CashBox {
         self.moneyDeposited = moneyDeposited
     }
     
-    mutating func insertMoney(amount: Int) {
+    func encode(with coder: NSCoder) {
+        coder.encode(totalRevenue, forKey: "totalRevenue")
+        coder.encode(moneyDeposited, forKey: "moneyDeposited")
+    }
+    
+    required init?(coder: NSCoder) {
+        self.totalRevenue = coder.decodeInteger(forKey: "totalRevenue")
+        self.moneyDeposited = coder.decodeInteger(forKey: "moneyDeposited")
+    }
+    
+    func insertMoney(amount: Int) {
         moneyDeposited += amount
     }
     
-    mutating func increaseRevenue(by amount: Int) {
+    func increaseRevenue(by amount: Int) {
         moneyDeposited -= amount
         totalRevenue += amount
     }

--- a/VendingMachineApp/VendingMachineApp/Models/Coffee.swift
+++ b/VendingMachineApp/VendingMachineApp/Models/Coffee.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 class Coffee: Beverage, HotServable, CaffeineContainable {
-    
     private let servingTemperature: Int
     private let caffeineAmount: Int
     
@@ -16,6 +15,18 @@ class Coffee: Beverage, HotServable, CaffeineContainable {
         self.servingTemperature = servingTemperature
         self.caffeineAmount = caffeineAmount
         super.init(brand: brand, volume: volume, price: price, name: name, calorie: calorie, imageName: imageName, manufactured: manufactured, expiredAfter: expiredAfter)
+    }
+    
+    required init?(coder: NSCoder) {
+        self.servingTemperature = coder.decodeInteger(forKey: "servingTemperature")
+        self.caffeineAmount = coder.decodeInteger(forKey: "caffeineAmount")
+        super.init(coder: coder)
+    }
+    
+    override func encode(with coder: NSCoder) {
+        coder.encode(servingTemperature, forKey: "servingTemperature")
+        coder.encode(caffeineAmount, forKey: "caffeineAmount")
+        super.encode(with: coder)
     }
     
     func isHotter(than referenceTemperature: Int) -> Bool {

--- a/VendingMachineApp/VendingMachineApp/Models/EnergyDrink.swift
+++ b/VendingMachineApp/VendingMachineApp/Models/EnergyDrink.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 class EnergyDrink: Beverage, CaffeineContainable, CarbonationHavable {
-    
     private let caffeineAmount: Int
     private let isCarbonated: Bool
     
@@ -16,6 +15,18 @@ class EnergyDrink: Beverage, CaffeineContainable, CarbonationHavable {
         self.caffeineAmount = caffeineAmount
         self.isCarbonated = isCarbonated
         super.init(brand: brand, volume: volume, price: price, name: name, calorie: calorie, imageName: imageName, manufactured: manufactured, expiredAfter: expiredAfter)
+    }
+    
+    required init?(coder: NSCoder) {
+        self.caffeineAmount = coder.decodeInteger(forKey: "caffeineAmount")
+        self.isCarbonated = coder.decodeBool(forKey: "isCarbonated")
+        super.init(coder: coder)
+    }
+    
+    override func encode(with coder: NSCoder) {
+        coder.encode(caffeineAmount, forKey: "caffeineAmount")
+        coder.encode(isCarbonated, forKey: "isCarbonated")
+        super.encode(with: coder)
     }
     
     func hasCaffeine() -> Bool {

--- a/VendingMachineApp/VendingMachineApp/Models/FlavoredMilk.swift
+++ b/VendingMachineApp/VendingMachineApp/Models/FlavoredMilk.swift
@@ -8,17 +8,26 @@
 import Foundation
 
 class FlavoredMilk: Milk {
-    
-    enum MilkFlavor {
+    enum MilkFlavor: String, Codable {
         case strawberry
         case chocolate
         case banana
     }
     
-    private let flavor: MilkFlavor
+    private let flavor: MilkFlavor!
     
     init(brand: String, volume: Int, price: Int, name: String, calorie: Int, imageName: String, manufactured: Date?, expiredAfter: Date?, lactoseAmount: Int, flavor: MilkFlavor) {
         self.flavor = flavor
         super.init(brand: brand, volume: volume, price: price, name: name, calorie: calorie, imageName: imageName, manufactured: manufactured, expiredAfter: expiredAfter, lactoseAmount: lactoseAmount)
+    }
+    
+    required init?(coder: NSCoder) {
+        self.flavor = (coder as! NSKeyedUnarchiver).decodeDecodable(MilkFlavor.self, forKey: "flavor")
+        super.init(coder: coder)
+    }
+    
+    override func encode(with coder: NSCoder) {
+        try? (coder as! NSKeyedArchiver).encodeEncodable(flavor, forKey: "flavor")
+        super.encode(with: coder)
     }
 }

--- a/VendingMachineApp/VendingMachineApp/Models/Inventory.swift
+++ b/VendingMachineApp/VendingMachineApp/Models/Inventory.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class Inventory {
+class Inventory: NSObject, NSCoding {
     private let slots: [Slot]
     var slotCount: Int {
         return slots.count
@@ -21,6 +21,14 @@ class Inventory {
     
     convenience init(numberOfSlots: Int) {
         self.init(slots: (0..<numberOfSlots).map { _ in Slot() })
+    }
+    
+    func encode(with coder: NSCoder) {
+        coder.encode(slots, forKey: "slots")
+    }
+    
+    required init?(coder: NSCoder) {
+        self.slots = coder.decodeObject(forKey: "slots") as! [Slot]
     }
     
     func add(_ item: Beverage) {

--- a/VendingMachineApp/VendingMachineApp/Models/Inventory.swift
+++ b/VendingMachineApp/VendingMachineApp/Models/Inventory.swift
@@ -45,7 +45,9 @@ class Inventory {
     
     func takeStock() -> [Slot : ItemQuantity] {
         var inventoryDictionary: [Slot : ItemQuantity] = [:]
-        slots.forEach {
+        slots.filter {
+            !$0.isEmpty()
+        }.forEach {
             inventoryDictionary[$0] = $0.itemCount
         }
         return inventoryDictionary

--- a/VendingMachineApp/VendingMachineApp/Models/InventorySheet.swift
+++ b/VendingMachineApp/VendingMachineApp/Models/InventorySheet.swift
@@ -1,0 +1,29 @@
+//
+//  InventorySheet.swift
+//  VendingMachineApp
+//
+//  Created by Song on 2021/03/14.
+//
+
+import UIKit
+
+protocol InventoryTakeable {
+    func showInventorySheet(handler: (Dictionary<Slot, Int>.Element) -> ())
+}
+
+struct InventorySheet {
+    func createInventoryViewInfo(for vendingMachine: InventoryTakeable) -> [Slot: SlotView] {
+        var inventoryViewInfo: [Slot: SlotView] = [ : ]
+        vendingMachine.showInventorySheet {
+            inventoryViewInfo[$0.key] = makeSlotView(with: $0.key)
+        }
+        return inventoryViewInfo
+    }
+    
+    private func makeSlotView(with slot: Slot) -> SlotView {
+        let view = SlotView()
+        view.itemImageView.image = UIImage(named: slot.itemImageName ?? "")
+        view.itemQuantityLabel.text = "\(slot.itemCount)개"
+        return view
+    }
+}

--- a/VendingMachineApp/VendingMachineApp/Models/Milk.swift
+++ b/VendingMachineApp/VendingMachineApp/Models/Milk.swift
@@ -8,12 +8,21 @@
 import Foundation
 
 class Milk: Beverage, LactoseFree {
-    
     private let lactoseAmount: Int
     
     init(brand: String, volume: Int, price: Int, name: String, calorie: Int, imageName: String, manufactured: Date?, expiredAfter: Date?, lactoseAmount: Int) {
         self.lactoseAmount = lactoseAmount
         super.init(brand: brand, volume: volume, price: price, name: name, calorie: calorie, imageName: imageName, manufactured: manufactured, expiredAfter: expiredAfter)
+    }
+    
+    required init?(coder: NSCoder) {
+        self.lactoseAmount = coder.decodeInteger(forKey: "lactoseAmount")
+        super.init(coder: coder)
+    }
+    
+    override func encode(with coder: NSCoder) {
+        coder.encode(lactoseAmount, forKey: "lactoseAmount")
+        super.encode(with: coder)
     }
     
     func isLactoseFree() -> Bool {

--- a/VendingMachineApp/VendingMachineApp/Models/Order.swift
+++ b/VendingMachineApp/VendingMachineApp/Models/Order.swift
@@ -7,12 +7,22 @@
 
 import Foundation
 
-struct Order {
+class Order: NSObject, NSCoding {
     private let purchased: Date
     private let item: Beverage
     
     init(purchased: Date, item: Beverage) {
         self.purchased = purchased
         self.item = item
+    }
+    
+    func encode(with coder: NSCoder) {
+        coder.encode(purchased, forKey: "purchased")
+        coder.encode(item, forKey: "item")
+    }
+    
+    required init?(coder: NSCoder) {
+        self.purchased = coder.decodeObject(forKey: "purchased") as! Date
+        self.item = coder.decodeObject(forKey: "item") as! Beverage
     }
 }

--- a/VendingMachineApp/VendingMachineApp/Models/PurchaseHistory.swift
+++ b/VendingMachineApp/VendingMachineApp/Models/PurchaseHistory.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class PurchaseHistory {
+class PurchaseHistory: NSObject, NSCoding {
     private var orderList: [Order]
     var orderCount: Int {
         orderList.count
@@ -17,8 +17,16 @@ class PurchaseHistory {
         self.orderList = orderList
     }
     
-    convenience init() {
+    convenience override init() {
         self.init(orderList: [])
+    }
+    
+    func encode(with coder: NSCoder) {
+        coder.encode(orderList, forKey: "orderList")
+    }
+    
+    required init?(coder: NSCoder) {
+        self.orderList = coder.decodeObject(forKey: "orderList") as! [Order]
     }
     
     func add(_ order: Order) {

--- a/VendingMachineApp/VendingMachineApp/Models/Slot.swift
+++ b/VendingMachineApp/VendingMachineApp/Models/Slot.swift
@@ -73,4 +73,8 @@ class Slot: CustomStringConvertible, Hashable {
     func isHotDrinkSlot() -> Bool {
         return items.first { $0 is HotServable && ($0 as! HotServable).isHotter(than: 50) } != nil
     }
+    
+    func isEmpty() -> Bool {
+        return items.isEmpty
+    }
 }

--- a/VendingMachineApp/VendingMachineApp/Models/Slot.swift
+++ b/VendingMachineApp/VendingMachineApp/Models/Slot.swift
@@ -7,11 +7,7 @@
 
 import Foundation
 
-class Slot: CustomStringConvertible, Hashable {
-    static func == (lhs: Slot, rhs: Slot) -> Bool {
-        return lhs.items == rhs.items && lhs.itemCount == rhs.itemCount && lhs.firstItem == rhs.firstItem && lhs.itemImageName == rhs.itemImageName
-    }
-    
+class Slot: NSObject, NSCoding {
     private var items: [Beverage]
     var itemCount: Int {
         return items.count
@@ -22,7 +18,7 @@ class Slot: CustomStringConvertible, Hashable {
     var itemImageName: String? {
         return firstItem?.imageName
     }
-    var description: String {
+    override var description: String {
         guard let firstItemName = firstItem?.name else {
             return "Empty Slot"
         }
@@ -33,15 +29,30 @@ class Slot: CustomStringConvertible, Hashable {
         self.items = items
     }
     
-    convenience init() {
+    convenience override init() {
         self.init(items: [])
     }
     
-    func hash(into hasher: inout Hasher) {
+    func encode(with coder: NSCoder) {
+        coder.encode(items, forKey: "items")
+    }
+    
+    required init?(coder: NSCoder) {
+        self.items = coder.decodeObject(forKey: "items") as! [Beverage]
+    }
+    
+    public override func isEqual(_ other: Any?) -> Bool {
+        guard let other = other as? Slot else { return false }
+        return self.items == other.items && self.itemCount == other.itemCount && self.firstItem == other.firstItem && self.itemImageName == other.itemImageName
+    }
+    
+    public override var hash: Int {
+        var hasher = Hasher()
         hasher.combine(items)
         hasher.combine(itemCount)
         hasher.combine(firstItem)
         hasher.combine(itemImageName)
+        return hasher.finalize()
     }
     
     func stock(_ item: Beverage) {

--- a/VendingMachineApp/VendingMachineApp/Models/SoftDrink.swift
+++ b/VendingMachineApp/VendingMachineApp/Models/SoftDrink.swift
@@ -8,12 +8,21 @@
 import Foundation
 
 class SoftDrink: Beverage, CarbonationHavable {
-    
     private let isCarbonated: Bool
     
     init(brand: String, volume: Int, price: Int, name: String, calorie: Int, imageName: String, manufactured: Date?, expiredAfter: Date?, isCarbonated: Bool) {
         self.isCarbonated = isCarbonated
         super.init(brand: brand, volume: volume, price: price, name: name, calorie: calorie, imageName: imageName, manufactured: manufactured, expiredAfter: expiredAfter)
+    }
+    
+    required init?(coder: NSCoder) {
+        self.isCarbonated = coder.decodeBool(forKey: "isCarbonated")
+        super.init(coder: coder)
+    }
+    
+    override func encode(with coder: NSCoder) {
+        coder.encode(isCarbonated, forKey: "isCarbonated")
+        super.encode(with: coder)
     }
     
     func hasCarbonation() -> Bool {

--- a/VendingMachineApp/VendingMachineApp/Models/VendingMachine.swift
+++ b/VendingMachineApp/VendingMachineApp/Models/VendingMachine.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class VendingMachine: NSObject, NSCoding {
+class VendingMachine: NSObject, NSCoding, InventoryTakeable {
     enum Notification {
         static let DidChangeInventory = Foundation.Notification.Name("DidChangeInventory")
         static let DidChangeBalance = Foundation.Notification.Name("DidChangeBalance")
@@ -101,5 +101,12 @@ class VendingMachine: NSObject, NSCoding {
     
     func showPurchaseHistory() -> PurchaseHistory {
         return soldItems
+    }
+    
+    func showInventorySheet(handler: (Dictionary<Slot, Int>.Element) -> ()) {
+        let inventorySheet = self.takeInventory()
+        inventorySheet.forEach {
+            handler($0)
+        }
     }
 }

--- a/VendingMachineApp/VendingMachineApp/Models/VendingMachine.swift
+++ b/VendingMachineApp/VendingMachineApp/Models/VendingMachine.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct VendingMachine {
+class VendingMachine: NSObject, NSCoding {
     enum Notification {
         static let DidChangeInventory = Foundation.Notification.Name("DidChangeInventory")
         static let DidChangeBalance = Foundation.Notification.Name("DidChangeBalance")
@@ -21,10 +21,22 @@ struct VendingMachine {
         self.inventory = Inventory(numberOfSlots: numberOfSlots)
         self.cashBox = CashBox(totalRevenue: 0, moneyDeposited: 0)
         self.soldItems = PurchaseHistory()
-        NotificationCenter.default.post(name: Notification.DidChangeBalance, object: self)
+        NotificationCenter.default.post(name: Notification.DidChangeBalance, object: nil)
     }
     
-    mutating func insertMoney(amount: Int) {
+    func encode(with coder: NSCoder) {
+        coder.encode(inventory, forKey: "inventory")
+        coder.encode(cashBox, forKey: "cashBox")
+        coder.encode(soldItems, forKey: "soldItems")
+    }
+    
+    required init?(coder: NSCoder) {
+        self.inventory = coder.decodeObject(forKey: "inventory") as! Inventory
+        self.cashBox = coder.decodeObject(forKey: "cashBox") as! CashBox
+        self.soldItems = coder.decodeObject(forKey: "soldItems") as! PurchaseHistory
+    }
+    
+    func insertMoney(amount: Int) {
         cashBox.insertMoney(amount: amount)
         NotificationCenter.default.post(name: Notification.DidChangeBalance, object: self)
     }
@@ -51,7 +63,7 @@ struct VendingMachine {
         return purchasableItems
     }
     
-    mutating func vend(itemNamed name: String) -> Beverage? {
+    func vend(itemNamed name: String) -> Beverage? {
         var vendedItem: Beverage?
         inventory.showSlots {
             if $0.compareName(with: name) {

--- a/VendingMachineApp/VendingMachineApp/Models/ZeroCalorieSoftDrink.swift
+++ b/VendingMachineApp/VendingMachineApp/Models/ZeroCalorieSoftDrink.swift
@@ -12,4 +12,12 @@ class ZeroCalorieSoftDrink: SoftDrink {
     init(brand: String, volume: Int, price: Int, name: String, imageName: String, manufactured: Date?, expiredAfter: Date?, isCarbonated: Bool) {
         super.init(brand: brand, volume: volume, price: price, name: name, calorie: 0, imageName: imageName, manufactured: manufactured, expiredAfter: expiredAfter, isCarbonated: isCarbonated)
     }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    override func encode(with coder: NSCoder) {
+        super.encode(with: coder)
+    }
 }

--- a/VendingMachineApp/VendingMachineApp/SceneDelegate.swift
+++ b/VendingMachineApp/VendingMachineApp/SceneDelegate.swift
@@ -8,9 +8,19 @@
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-    
     var window: UIWindow?
     var vendingMachine: VendingMachine!
+    let defaults = UserDefaults.standard
+    
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        do {
+            guard let vendingMachine = vendingMachine else { return }
+            let archived = try NSKeyedArchiver.archivedData(withRootObject: vendingMachine, requiringSecureCoding: false)
+            defaults.set(archived, forKey: "vendingMachine")
+        } catch {
+            print(error.localizedDescription)
+        }
+    }
     
     private func initialSetupVendingMachine() {
         vendingMachine = VendingMachine(numberOfSlots: 5)

--- a/VendingMachineApp/VendingMachineApp/SceneDelegate.swift
+++ b/VendingMachineApp/VendingMachineApp/SceneDelegate.swift
@@ -8,8 +8,15 @@
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-
+    
     var window: UIWindow?
-
+    var vendingMachine: VendingMachine!
+    
+    private func initialSetupVendingMachine() {
+        vendingMachine = VendingMachine(numberOfSlots: 5)
+        let beverageFactoryList: [BeverageFactory] = [DenmarkStrawberryMilkFactory(), MaeilChocolateMilkFactory(), ZeroSugarCokeFactory(), GeorgiaMaxFactory(), RedBullFactory()]
+        beverageFactoryList.forEach { factory in
+            vendingMachine.bulkInsert(itemFrom: factory, quantity: 5, manufactured: Date().formattedDate(from: "20210222"), expiredAfter: Date().formattedDate(from: "20210302"))
+        }
+    }
 }
-

--- a/VendingMachineApp/VendingMachineApp/SceneDelegate.swift
+++ b/VendingMachineApp/VendingMachineApp/SceneDelegate.swift
@@ -22,6 +22,18 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
     }
     
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        if let archivedData = defaults.object(forKey: "vendingMachine") {
+            do {
+                vendingMachine = try NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(archivedData as! Data) as? VendingMachine
+            } catch {
+                print(error.localizedDescription)
+            }
+        } else {
+            initialSetupVendingMachine()
+        }
+    }
+    
     private func initialSetupVendingMachine() {
         vendingMachine = VendingMachine(numberOfSlots: 5)
         let beverageFactoryList: [BeverageFactory] = [DenmarkStrawberryMilkFactory(), MaeilChocolateMilkFactory(), ZeroSugarCokeFactory(), GeorgiaMaxFactory(), RedBullFactory()]

--- a/VendingMachineApp/VendingMachineApp/Views/SlotView.swift
+++ b/VendingMachineApp/VendingMachineApp/Views/SlotView.swift
@@ -8,6 +8,10 @@
 import UIKit
 
 class SlotView: UIView {
+    enum Notification {
+        static let DidButtonPressed = Foundation.Notification.Name("DidButtonPressed")
+    }
+    
     private let nibName = "SlotView"
     
     @IBOutlet weak var itemQuantityIncrementButton: UIButton!
@@ -31,5 +35,12 @@ class SlotView: UIView {
         itemImageView.layer.cornerRadius = 25.0
         itemImageView.layer.masksToBounds = true
         self.addSubview(nibView)
+        
+        itemQuantityIncrementButton.addTarget(self, action: #selector(itemQuantityIncrementButtonPressed(_:)), for: .touchUpInside)
+    }
+    
+    @objc func itemQuantityIncrementButtonPressed(_ sender: UIButton) {
+        let userInfo = ["SlotView" : self]
+        NotificationCenter.default.post(name: Notification.DidButtonPressed, object: nil, userInfo: userInfo)
     }
 }

--- a/VendingMachineApp/VendingMachineAppTests/InventoryTests.swift
+++ b/VendingMachineApp/VendingMachineAppTests/InventoryTests.swift
@@ -60,16 +60,14 @@ class InventoryTests: XCTestCase {
     func test_자판기앱_빈인벤토리에_아이템추가() throws {
         inventoryWith6EmptySlots.add(strawberryMilk1)
         let inventorySheet = inventoryWith6EmptySlots.takeStock()
-        XCTAssertEqual(inventorySheet, [Slot(items: [strawberryMilk1]): 1,
-                                        Slot(): 0])
+        XCTAssertEqual(inventorySheet, [Slot(items: [strawberryMilk1]): 1])
     }
     
     func test_자판기앱_인벤토리에_같은아이템추가() throws {
         inventoryWith6EmptySlots.add(strawberryMilk1)
         inventoryWith6EmptySlots.add(strawberryMilk2)
         let inventorySheet = inventoryWith6EmptySlots.takeStock()
-        XCTAssertEqual(inventorySheet, [Slot(items: [strawberryMilk1, strawberryMilk2]): 2,
-                                        Slot(): 0])
+        XCTAssertEqual(inventorySheet, [Slot(items: [strawberryMilk1, strawberryMilk2]): 2])
     }
     
     func test_자판기앱_인벤토리에_다른아이템추가() throws {
@@ -77,8 +75,7 @@ class InventoryTests: XCTestCase {
         inventoryWith6EmptySlots.add(georgiaMax1)
         let inventorySheet = inventoryWith6EmptySlots.takeStock()
         XCTAssertEqual(inventorySheet, [Slot(items: [strawberryMilk1]): 1,
-                                        Slot(items: [georgiaMax1]): 1,
-                                        Slot(): 0])
+                                        Slot(items: [georgiaMax1]): 1])
     }
     
     func test_자판기앱_상품재고리턴() throws {
@@ -90,7 +87,6 @@ class InventoryTests: XCTestCase {
         inventoryWith6EmptySlots.add(georgiaMax3)
         let inventorySheet = inventoryWith6EmptySlots.takeStock()
         XCTAssertEqual(inventorySheet, [Slot(items: [strawberryMilk1, strawberryMilk2, strawberryMilk3]): 3,
-                                        Slot(items: [georgiaMax1, georgiaMax2, georgiaMax3]): 3,
-                                        Slot(): 0])
+                                        Slot(items: [georgiaMax1, georgiaMax2, georgiaMax3]): 3])
     }
 }

--- a/VendingMachineApp/VendingMachineAppTests/VendingMachineTests.swift
+++ b/VendingMachineApp/VendingMachineAppTests/VendingMachineTests.swift
@@ -120,8 +120,7 @@ class VendingMachineTests: XCTestCase {
     func test_자판기앱_빈자판기에_상품추가() throws {
         emptyVendingMachine.add(item: strawberryMilk1)
         let inventorySheet = emptyVendingMachine.takeInventory()
-        XCTAssertEqual(inventorySheet, [Slot(items: [strawberryMilk1]): 1,
-                                        Slot(): 0])
+        XCTAssertEqual(inventorySheet, [Slot(items: [strawberryMilk1]): 1])
     }
     
     func test_자판기앱_제품있는자판기에_상품추가() throws {
@@ -131,8 +130,7 @@ class VendingMachineTests: XCTestCase {
                                         Slot(items: [chocolateMilk1, chocolateMilk2, chocolateMilk3]): 3,
                                         Slot(items: [zeroSugarCoke1, zeroSugarCoke2, zeroSugarCoke3]): 3,
                                         Slot(items: [georgiaMax1, georgiaMax2, georgiaMax3]): 3,
-                                        Slot(items: [redBull1, redBull2, redBull3]): 3,
-                                        Slot(items: []): 0])
+                                        Slot(items: [redBull1, redBull2, redBull3]): 3])
     }
     
     func test_자판기앱_상품구매() throws {
@@ -167,7 +165,6 @@ class VendingMachineTests: XCTestCase {
                                         Slot(items: [chocolateMilk1, chocolateMilk2, chocolateMilk3]): 3,
                                         Slot(items: [zeroSugarCoke1, zeroSugarCoke2, zeroSugarCoke3]): 3,
                                         Slot(items: [georgiaMax1, georgiaMax2, georgiaMax3]): 3,
-                                        Slot(items: [redBull1, redBull2, redBull3]): 3,
-                                        Slot(items: []): 0])
+                                        Slot(items: [redBull1, redBull2, redBull3]): 3])
     }
 }


### PR DESCRIPTION
### 스텝별 작업 목록
#### Step3 피드백
- [x] superview를 사용하지 않고 추가 button이 선택된 item을 추가하도록 코드 구현
- [x] 반복되는 `bulkInsert()` 함수 forEach문으로 처리
- [x] `InventorySheet` 구조체와 `InventoryTakeable` 프로토콜 추가, `configureInventoryView()` 함수에 적용
- [x] Beverage image 관련 파트 개선
- [ ] 총수익을 화면에 표시
#### Step4 요구사항
- [x] VendingMachine 변수를 SceneDelegate로 이동
- [x] VendingMachine 객체를 아카이브해 하나의 데이터값으로 변형
- [x] 앱 종료 (background) 시점 콜백 함수에서 객체 속성을 UserDefaults로 저장
- [x] 앱 시작 (active) 시점 콜백 함수에서 저장된 데이터 값을 언아카이브해 VendingMachine 객체 생성

### 학습 키워드
* AppDelegate, SceneDelegate
* NSObject, NSCoding

### 고민과 해결
* 지난 Step에서 superview를 사용하지 않고 UIButton이 자신이 속한 SlotView를 알도록 개선하라는 피드백을 받았었습니다.
버튼이 눌리면 SlotView 자신을 userInfo에 담아 NotificationCenter에 `DidButtonPressed`라는 이벤트를 등록하고 이를 발생시킬 수 있도록 했으며 viewController에서는 이 이벤트를 받아서 아이템을 추가할 수 있도록 했습니다.
`Button -> SlotView에게 이벤트를 보내고 -> SlotView는 뷰 컨트롤러에게 SlotView를 sender로 이벤트를 보내면 어떨까요?`라는 피드백에 완전 부합하는 것 같진 않지만 할 수 있는 선에서 한번 구현해보았습니다😭
* AppDelegate 관련 문서를 읽다 `sceneDidBecomeActive(_:)`와 `sceneDidEnterBackground(_:)`를 대신 사용하라는 안내 사항을 보고 AppDelegate 대신 SceneDelegate에 VendingMachine 객체의 저장 및 복원 코드를 구현해주었습니다.

### 질문거리
* (1) 앱에서 아이템 혹은 금액을 추가한 후 홈버튼을 한번 눌러 나갔다 다시 앱으로 돌아오는 경우나 (2) 앱을 다시 run하는 경우에는 VendingMachine 객체가 잘 저장, 복원되지만 홈버튼을 두번 누른 후 스와이프해 앱을 강제 종료하는 경우 앱이 아예 켜지질 않습니다. (까만 화면이 잠깐 켜졌다 바로 꺼져버립니다.)
viewController에서 `viewDidAppear(_ animated: Bool)` 함수를 호출해 InventoryView와 CashBoxView를 업데이트 하는 것이 그 원인이 아닐까 하는데 (`viewDidAppear`가 없으면 SlotView가 제대로 안보일 뿐 강제 종료 후에도 앱이 켜지긴 합니다) 이곳 외 어디에서 view를 업데이트 해줘야 하는지를 찾지 못해 고민하다 일단 PR을 보내봅니다🥲