### PR TITLE
[Soo] Step5 - 재고와 자판기 충전 금액 표시를 위한 Notification 추가

### DIFF
--- a/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
+++ b/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		D0636C3625E4A7020087E3E8 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D0636C3425E4A7020087E3E8 /* Main.storyboard */; };
 		D0636C3825E4A7030087E3E8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D0636C3725E4A7030087E3E8 /* Assets.xcassets */; };
 		D0636C3B25E4A7030087E3E8 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D0636C3925E4A7030087E3E8 /* LaunchScreen.storyboard */; };
+		D09327BF26004EC00000B13B /* ChargeUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09327BE26004EC00000B13B /* ChargeUnit.swift */; };
 		D09C7B6525E4A7B400429153 /* Coffee.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09C7B6425E4A7B400429153 /* Coffee.swift */; };
 		D0A3FADA25E8ED64004FF690 /* PurchaseHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A3FAD925E8ED64004FF690 /* PurchaseHistory.swift */; };
 		D0C3DA9325EE042A0019C643 /* Drinkable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C3DA9125EE042A0019C643 /* Drinkable.swift */; };
@@ -59,6 +60,7 @@
 		D0636C3725E4A7030087E3E8 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		D0636C3A25E4A7030087E3E8 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		D0636C3C25E4A7030087E3E8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D09327BE26004EC00000B13B /* ChargeUnit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChargeUnit.swift; sourceTree = "<group>"; };
 		D09C7B6425E4A7B400429153 /* Coffee.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coffee.swift; sourceTree = "<group>"; };
 		D0A3FAD925E8ED64004FF690 /* PurchaseHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseHistory.swift; sourceTree = "<group>"; };
 		D0C3DA9125EE042A0019C643 /* Drinkable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Drinkable.swift; sourceTree = "<group>"; };
@@ -138,6 +140,7 @@
 		D0A3FAD025E88DEF004FF690 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				D09327BE26004EC00000B13B /* ChargeUnit.swift */,
 				D0F5E57325E4C721008D4C5D /* VendingMachine.swift */,
 				D0A3FAD925E8ED64004FF690 /* PurchaseHistory.swift */,
 				D0F5E57625E4C7A1008D4C5D /* Drinks.swift */,
@@ -274,6 +277,7 @@
 				D055C63C25E62F9800C4D1C3 /* BananaMilk.swift in Sources */,
 				D0636C2F25E4A7020087E3E8 /* AppDelegate.swift in Sources */,
 				D0F5E57725E4C7A1008D4C5D /* Drinks.swift in Sources */,
+				D09327BF26004EC00000B13B /* ChargeUnit.swift in Sources */,
 				D0636C3125E4A7020087E3E8 /* SceneDelegate.swift in Sources */,
 				D04D34C025FA133A00573C4B /* ArchivingManager.swift in Sources */,
 				D09C7B6525E4A7B400429153 /* Coffee.swift in Sources */,

--- a/VendingMachineApp/VendingMachineApp/AppDelegate.swift
+++ b/VendingMachineApp/VendingMachineApp/AppDelegate.swift
@@ -10,14 +10,10 @@ import UIKit
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-    var vendingMachine: VendingMachine?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         if let data = UserDefaults.standard.object(forKey: "vm") as? Data, let vm = ArchivingManager.unarchive(with: data) as? VendingMachine {
-            vendingMachine = vm
-        } else {
-            let drinks = Drinks()
-            vendingMachine = VendingMachine(drinks: drinks, chargedCoins: 0)
+            VendingMachine.shared = vm
         }
         return true
     }

--- a/VendingMachineApp/VendingMachineApp/Base.lproj/Main.storyboard
+++ b/VendingMachineApp/VendingMachineApp/Base.lproj/Main.storyboard
@@ -25,9 +25,6 @@
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BZA-RC-Srq">
                                                 <rect key="frame" x="113" y="0.0" width="30" height="126.5"/>
                                                 <state key="normal" title="추가"/>
-                                                <connections>
-                                                    <action selector="addStockButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="s6S-3O-IrS"/>
-                                                </connections>
                                             </button>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="banana_milk" translatesAutoresizingMaskIntoConstraints="NO" id="N58-bC-3EY">
                                                 <rect key="frame" x="43" y="136.5" width="170.5" height="127"/>
@@ -47,9 +44,6 @@
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SSQ-gt-i1A">
                                                 <rect key="frame" x="113" y="0.0" width="30" height="126.5"/>
                                                 <state key="normal" title="추가"/>
-                                                <connections>
-                                                    <action selector="addStockButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="tki-hb-nxt"/>
-                                                </connections>
                                             </button>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="cantata_coffee" translatesAutoresizingMaskIntoConstraints="NO" id="uo8-H2-XEP">
                                                 <rect key="frame" x="28" y="136.5" width="200" height="127"/>
@@ -69,9 +63,6 @@
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="a0G-P6-ygs">
                                                 <rect key="frame" x="113" y="0.0" width="30" height="126.5"/>
                                                 <state key="normal" title="추가"/>
-                                                <connections>
-                                                    <action selector="addStockButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="TRm-9d-036"/>
-                                                </connections>
                                             </button>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="fanta" translatesAutoresizingMaskIntoConstraints="NO" id="OQD-GD-Qgq">
                                                 <rect key="frame" x="43" y="136.5" width="170.5" height="127"/>
@@ -96,16 +87,10 @@
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FiJ-NV-boI">
                                         <rect key="frame" x="0.0" y="0.0" width="46" height="30"/>
                                         <state key="normal" title="+1000"/>
-                                        <connections>
-                                            <action selector="charge:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Ufs-C5-kJ7"/>
-                                        </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zZh-O5-Ht6">
                                         <rect key="frame" x="0.0" y="50" width="46" height="30"/>
                                         <state key="normal" title="+5000"/>
-                                        <connections>
-                                            <action selector="charge:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ihA-dg-Qi7"/>
-                                        </connections>
                                     </button>
                                 </subviews>
                             </stackView>
@@ -136,11 +121,11 @@
                         <outletCollection property="drinkImages" destination="uo8-H2-XEP" collectionClass="NSMutableArray" id="Q13-Jh-SQS"/>
                         <outletCollection property="drinkStockLabels" destination="vFf-uw-w7G" collectionClass="NSMutableArray" id="pi1-MX-4G9"/>
                         <outletCollection property="drinkImages" destination="OQD-GD-Qgq" collectionClass="NSMutableArray" id="Ede-nL-Ofd"/>
-                        <outletCollection property="addButtons" destination="BZA-RC-Srq" collectionClass="NSMutableArray" id="YRL-Yf-d1j"/>
-                        <outletCollection property="addButtons" destination="SSQ-gt-i1A" collectionClass="NSMutableArray" id="Zh2-2K-nqn"/>
-                        <outletCollection property="addButtons" destination="a0G-P6-ygs" collectionClass="NSMutableArray" id="Gkk-kC-fhl"/>
                         <outletCollection property="chargeButtons" destination="FiJ-NV-boI" collectionClass="NSMutableArray" id="FS1-hi-GkF"/>
                         <outletCollection property="chargeButtons" destination="zZh-O5-Ht6" collectionClass="NSMutableArray" id="xvo-L6-JoE"/>
+                        <outletCollection property="addButtons" destination="BZA-RC-Srq" collectionClass="NSMutableArray" id="qzb-PM-F9I"/>
+                        <outletCollection property="addButtons" destination="SSQ-gt-i1A" collectionClass="NSMutableArray" id="9wr-Rk-kiM"/>
+                        <outletCollection property="addButtons" destination="a0G-P6-ygs" collectionClass="NSMutableArray" id="lPX-Fa-tHJ"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/VendingMachineApp/VendingMachineApp/DrinkFactory.swift
+++ b/VendingMachineApp/VendingMachineApp/DrinkFactory.swift
@@ -9,15 +9,6 @@ import Foundation
 
 class DrinkFactory {
     static func createDrink(for drinkType: Drink.Type) -> Drink? {
-        switch drinkType {
-        case is BananaMilk.Type:
-            return BananaMilk(manufacturer: "빙그레", volume: 200, name: "빙그레바나나우유", manufacturedAt: Date(), price: 1000, temperature: 20, calorie: 200, fatContent: 5, farmCode: "B", expiredAt: Date())
-        case is Cantata.Type:
-            return Cantata(manufacturer: "롯데칠성음료", volume: 200, name: "칸타타프리미엄라떼", manufacturedAt: Date(), price: 2000, caffeineContent: 10, temperature: 100, calorie: 100, flavor: .latte, expiredAt: Date())
-        case is Fanta.Type:
-            return Fanta(manufacturer: "코카콜라컴퍼니", volume: 200, name: "환타", manufacturedAt: Date(), price: 1000, calorie: 100, packageMaterial: .can, temperature: 10, sugarContent: 10, expiredAt: Date())
-        default:
-            return nil
-        }
+        return drinkType.init()
     }
 }

--- a/VendingMachineApp/VendingMachineApp/Models/BananaMilk.swift
+++ b/VendingMachineApp/VendingMachineApp/Models/BananaMilk.swift
@@ -20,6 +20,10 @@ class BananaMilk: Milk  {
         super.init(coder: coder)
     }
     
+    required convenience init() {
+        self.init(manufacturer: "빙그레", volume: 200, name: "빙그레바나나우유", manufacturedAt: Date(), price: 1000, temperature: 20, calorie: 200, fatContent: 5, farmCode: "B", expiredAt: Date())
+    }
+    
     override func encode(with coder: NSCoder) {
         coder.encode(farmCode, forKey: "farmCode")
         super.encode(with: coder)

--- a/VendingMachineApp/VendingMachineApp/Models/Cantata.swift
+++ b/VendingMachineApp/VendingMachineApp/Models/Cantata.swift
@@ -26,6 +26,10 @@ class Cantata: Coffee {
         super.init(coder: coder)
     }
     
+    required convenience init() {
+        self.init(manufacturer: "롯데칠성음료", volume: 200, name: "칸타타프리미엄라떼", manufacturedAt: Date(), price: 2000, caffeineContent: 10, temperature: 100, calorie: 100, flavor: .latte, expiredAt: Date())
+    }
+    
     override func encode(with coder: NSCoder) {
         coder.encode(flavor.rawValue, forKey: "flavor")
         super.encode(with: coder)

--- a/VendingMachineApp/VendingMachineApp/Models/ChargeUnit.swift
+++ b/VendingMachineApp/VendingMachineApp/Models/ChargeUnit.swift
@@ -1,0 +1,13 @@
+//
+//  ChargeUnit.swift
+//  VendingMachineApp
+//
+//  Created by Ador on 2021/03/16.
+//
+
+import Foundation
+
+enum ChargeUnit: Int, CaseIterable {
+    case _1000 = 1000
+    case _5000 = 5000
+}

--- a/VendingMachineApp/VendingMachineApp/Models/Coffee.swift
+++ b/VendingMachineApp/VendingMachineApp/Models/Coffee.swift
@@ -20,6 +20,10 @@ class Coffee: Drink {
         super.init(coder: coder)
     }
     
+    required init() {
+        fatalError("init() has not been implemented")
+    }
+    
     override func encode(with coder: NSCoder) {
         coder.encode(caffeineContent, forKey: "caffeineContent")
         super.encode(with: coder)

--- a/VendingMachineApp/VendingMachineApp/Models/Drink.swift
+++ b/VendingMachineApp/VendingMachineApp/Models/Drink.swift
@@ -42,6 +42,17 @@ class Drink: NSObject, NSCoding {
         self.calorie = coder.decodeInteger(forKey: "calorie")
     }
     
+    required override init() {
+        self.manufacturer = "manufacturer"
+        self.volume = 0
+        self.name = "name"
+        self.manufacturedAt = Date()
+        self.price = 0
+        self.temperature = 0
+        self.calorie = 0
+        self.expiredAt = Date()
+    }
+    
     func encode(with coder: NSCoder) {
         coder.encode(manufacturer, forKey: "manufacturer")
         coder.encode(volume, forKey: "volume")

--- a/VendingMachineApp/VendingMachineApp/Models/Drinks.swift
+++ b/VendingMachineApp/VendingMachineApp/Models/Drinks.swift
@@ -8,7 +8,11 @@
 import Foundation
 
 class Drinks: NSObject, NSCoding {
-    private var drinks: [Drink] = []
+    private var drinks: [Drink] = [] {
+        didSet {
+            NotificationCenter.default.post(name: .updatedDrinkStock, object: self, userInfo: nil)
+        }
+    }
     
     override var description: String {
         return "\(drinks)"

--- a/VendingMachineApp/VendingMachineApp/Models/Drinks.swift
+++ b/VendingMachineApp/VendingMachineApp/Models/Drinks.swift
@@ -39,8 +39,8 @@ class Drinks: NSObject, NSCoding {
         return availableDrinks
     }
 
-    func remove(drink: Drink) {        
-        if let index = drinks.firstIndex(of: drink) {
+    func remove(drink: Drink.Type) {
+        if let index = drinks.firstIndex(where: {ObjectIdentifier(type(of: $0)) == ObjectIdentifier(drink)}) {
             drinks.remove(at: index)
         }
     }

--- a/VendingMachineApp/VendingMachineApp/Models/Drinks.swift
+++ b/VendingMachineApp/VendingMachineApp/Models/Drinks.swift
@@ -10,7 +10,7 @@ import Foundation
 class Drinks: NSObject, NSCoding {
     private var drinks: [Drink] = [] {
         didSet {
-            NotificationCenter.default.post(name: .updatedDrinkStock, object: self, userInfo: nil)
+            NotificationCenter.default.post(name: VendingMachine.updatedDrinkStock, object: self, userInfo: nil)
         }
     }
     

--- a/VendingMachineApp/VendingMachineApp/Models/Fanta.swift
+++ b/VendingMachineApp/VendingMachineApp/Models/Fanta.swift
@@ -25,6 +25,10 @@ class Fanta: Soda {
         super.init(coder: coder)
     }
     
+    required convenience init() {
+        self.init(manufacturer: "코카콜라컴퍼니", volume: 200, name: "환타", manufacturedAt: Date(), price: 1000, calorie: 100, packageMaterial: .can, temperature: 10, sugarContent: 10, expiredAt: Date())
+    }
+    
     override func encode(with coder: NSCoder) {
         coder.encode(packageMaterial.rawValue, forKey: "packageMaterial")
         super.encode(with: coder)

--- a/VendingMachineApp/VendingMachineApp/Models/Milk.swift
+++ b/VendingMachineApp/VendingMachineApp/Models/Milk.swift
@@ -29,7 +29,7 @@ class Milk: Drink {
         super.encode(with: coder)
     }
     
-    func isLowFat() -> Bool {
-        return fatContent < 3
+    func isLowFat(standard: Int) -> Bool {
+        return fatContent < standard
     }
 }

--- a/VendingMachineApp/VendingMachineApp/Models/Milk.swift
+++ b/VendingMachineApp/VendingMachineApp/Models/Milk.swift
@@ -20,6 +20,10 @@ class Milk: Drink {
         super.init(coder: coder)
     }
     
+    required init() {
+        fatalError("init() has not been implemented")
+    }
+    
     override func encode(with coder: NSCoder) {
         coder.encode(fatContent, forKey: "fatContent")
         super.encode(with: coder)

--- a/VendingMachineApp/VendingMachineApp/Models/Soda.swift
+++ b/VendingMachineApp/VendingMachineApp/Models/Soda.swift
@@ -25,6 +25,10 @@ class Soda: Drink, Sweetable {
         super.init(coder: coder)
     }
     
+    required init() {
+        fatalError("init() has not been implemented")
+    }
+    
     override func encode(with coder: NSCoder) {
         coder.encode(sugarContent, forKey: "sugarContent")
         super.encode(with: coder)

--- a/VendingMachineApp/VendingMachineApp/Models/VendingMachine.swift
+++ b/VendingMachineApp/VendingMachineApp/Models/VendingMachine.swift
@@ -8,11 +8,12 @@
 import Foundation
 
 class VendingMachine: NSObject, NSCoding {
+    static var shared = VendingMachine(drinks: Drinks(), chargedCoins: 0)
     private var standardHotTempertaure = 70
     private var drinks: Drinks
     private var chargedCoins: Int {
         didSet {
-            NotificationCenter.default.post(name: .updatedRemainCoins, object: self, userInfo: nil)
+            NotificationCenter.default.post(name: VendingMachine.updatedRemainCoins, object: self, userInfo: nil)
         }
     }
     private var purchaseHistory: PurchaseHistory
@@ -81,4 +82,9 @@ class VendingMachine: NSObject, NSCoding {
     func getPurchaseHistory() -> [Drink] {
         return purchaseHistory.purchasedDrinks
     }
+}
+
+extension VendingMachine {
+    static let updatedDrinkStock = Notification.Name("updatedDrinkStock")
+    static let updatedRemainCoins = Notification.Name("updatedRemainCoins")
 }

--- a/VendingMachineApp/VendingMachineApp/Models/VendingMachine.swift
+++ b/VendingMachineApp/VendingMachineApp/Models/VendingMachine.swift
@@ -52,10 +52,14 @@ class VendingMachine: NSObject, NSCoding {
         return drinks.getAvailableDrinks(with: chargedCoins)
     }
     
-    func purchase(drink: Drink) {
-        chargedCoins -= drink.price
-        drinks.remove(drink: drink)
-        purchaseHistory.add(drink: drink)
+    func purchase(drink: Drink.Type) {
+        drinks.getAllDrinks().forEach { (key, value) in
+            if key == ObjectIdentifier(drink), let instance = value.first {
+                chargedCoins -= instance.price
+                drinks.remove(drink: drink)
+                purchaseHistory.add(drink: instance)
+            }
+        }
     }
     
     func checkRemainCoins() -> Int {

--- a/VendingMachineApp/VendingMachineApp/Models/VendingMachine.swift
+++ b/VendingMachineApp/VendingMachineApp/Models/VendingMachine.swift
@@ -10,7 +10,11 @@ import Foundation
 class VendingMachine: NSObject, NSCoding {
     private var standardHotTempertaure = 70
     private var drinks: Drinks
-    private var chargedCoins: Int
+    private var chargedCoins: Int {
+        didSet {
+            NotificationCenter.default.post(name: .updatedRemainCoins, object: self, userInfo: nil)
+        }
+    }
     private var purchaseHistory: PurchaseHistory
     override var description: String {
         return "\(drinks)"

--- a/VendingMachineApp/VendingMachineApp/SceneDelegate.swift
+++ b/VendingMachineApp/VendingMachineApp/SceneDelegate.swift
@@ -16,7 +16,15 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let _ = (scene as? UIWindowScene) else { return }
     }
     
+    func sceneWillResignActive(_ scene: UIScene) {
+        archiveVendingMachine()
+    }
+    
     func sceneDidEnterBackground(_ scene: UIScene) {
+        archiveVendingMachine()
+    }
+    
+    func archiveVendingMachine() {
         guard let vm = appDelegate.vendingMachine else {
             return
         }

--- a/VendingMachineApp/VendingMachineApp/SceneDelegate.swift
+++ b/VendingMachineApp/VendingMachineApp/SceneDelegate.swift
@@ -10,7 +10,6 @@ import UIKit
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
-    private var appDelegate: AppDelegate = UIApplication.shared.delegate as! AppDelegate
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let _ = (scene as? UIWindowScene) else { return }
@@ -25,10 +24,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
     
     func archiveVendingMachine() {
-        guard let vm = appDelegate.vendingMachine else {
-            return
-        }
-        let data = ArchivingManager.archive(with: vm)
+        let data = ArchivingManager.archive(with: VendingMachine.shared)
         UserDefaults.standard.set(data, forKey: "vm")
     }
 }

--- a/VendingMachineApp/VendingMachineApp/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/ViewController.swift
@@ -16,7 +16,7 @@ class ViewController: UIViewController {
     @IBOutlet var chargeButtons: [UIButton]!
     
     private var appDelegate: AppDelegate = UIApplication.shared.delegate as! AppDelegate
-    private let chargeAmount = [1000, 5000]
+    private var chargeAmount = ChargeUnit.allCases
     private let drinkType = [BananaMilk.self, Cantata.self, Fanta.self]
     private var buttonsForDrink: [UIButton: Drink.Type] = [:]
     private var buttonsForCharge: [UIButton: Int] = [:]
@@ -46,7 +46,7 @@ class ViewController: UIViewController {
         }
         
         chargeButtons.enumerated().forEach {
-            buttonsForCharge[$1] = chargeAmount[$0]
+            buttonsForCharge[$1] = chargeAmount[$0].rawValue
         }
     }
     

--- a/VendingMachineApp/VendingMachineApp/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/ViewController.swift
@@ -15,8 +15,8 @@ class ViewController: UIViewController {
     @IBOutlet var addButtons: [UIButton]!
     @IBOutlet var chargeButtons: [UIButton]!
     
-    private var appDelegate: AppDelegate = UIApplication.shared.delegate as! AppDelegate
-    private var chargeAmount = ChargeUnit.allCases
+    private let vm = VendingMachine.shared
+    private let chargeAmount = ChargeUnit.allCases
     private let drinkType = [BananaMilk.self, Cantata.self, Fanta.self]
     private var buttonsForDrink: [UIButton: Drink.Type] = [:]
     private var buttonsForCharge: [UIButton: Int] = [:]
@@ -24,10 +24,10 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        NotificationCenter.default.addObserver(forName: .updatedDrinkStock, object: nil, queue: .main) { [weak self] _ in
+        NotificationCenter.default.addObserver(forName: VendingMachine.updatedDrinkStock, object: nil, queue: .main) { [weak self] _ in
             self?.updateDrinkStockLabels()
         }
-        NotificationCenter.default.addObserver(forName: .updatedRemainCoins, object: nil, queue: .main) { [weak self] _ in
+        NotificationCenter.default.addObserver(forName: VendingMachine.updatedRemainCoins, object: nil, queue: .main) { [weak self] _ in
             self?.updateRemainCoinsLabel()
         }
         
@@ -66,9 +66,7 @@ class ViewController: UIViewController {
     }
     
     func updateDrinkStockLabels() {
-        guard let allDrinks = appDelegate.vendingMachine?.getAllDrinks() else {
-            return
-        }
+        let allDrinks = vm.getAllDrinks()
         drinkType.enumerated().forEach { index, type in
             let id = ObjectIdentifier(type)
             drinkStockLabels[index].text = "\(allDrinks[id]?.count ?? 0)개"
@@ -76,9 +74,7 @@ class ViewController: UIViewController {
     }
     
     func updateRemainCoinsLabel() {
-        guard let remainCoins = appDelegate.vendingMachine?.checkRemainCoins() else {
-            return
-        }
+        let remainCoins = vm.checkRemainCoins()
         remainCoinsLabel.text = "\(remainCoins)원"
     }
     
@@ -87,18 +83,13 @@ class ViewController: UIViewController {
         guard let type = buttonsForDrink[sender], let drink = DrinkFactory.createDrink(for: type) else {
             return
         }
-        appDelegate.vendingMachine?.addStock(for: drink)
+        vm.addStock(for: drink)
     }
     
     @objc func charge(_ sender: UIButton) {
-        guard let chargeAmount = buttonsForCharge[sender], let vm = appDelegate.vendingMachine else {
+        guard let chargeAmount = buttonsForCharge[sender] else {
             return
         }
         vm.charge(coins: chargeAmount)
     }
-}
-
-extension NSNotification.Name {
-    static let updatedDrinkStock = Notification.Name("updatedDrinkStock")
-    static let updatedRemainCoins = Notification.Name("updatedRemainCoins")
 }

--- a/VendingMachineApp/VendingMachineApp/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/ViewController.swift
@@ -88,7 +88,6 @@ class ViewController: UIViewController {
             return
         }
         appDelegate.vendingMachine?.addStock(for: drink)
-        NotificationCenter.default.post(name: .updatedDrinkStock, object: self, userInfo: nil)
     }
     
     @objc func charge(_ sender: UIButton) {
@@ -96,7 +95,6 @@ class ViewController: UIViewController {
             return
         }
         vm.charge(coins: chargeAmount)
-        NotificationCenter.default.post(name: .updatedRemainCoins, object: self, userInfo: nil)
     }
 }
 


### PR DESCRIPTION
### 주요 작업
- [x] 재고 수량과 충전 금액을 NotificationCenter를 사용해서 표시하도록 수정
- [x] 음료 객체 생성 시 Type.init 형태로 생성하도록 수정
- [x] 음료를 구입(배열에서 제거)할 때, 음료의 타입과 같은 instance 하나를 제거하도록 변경

### 학습 키워드
- NotificationCenter
- required init
- Application Life Cycle(AppDelegate, SceneDelegate)

### 고민과 해결 
- 홈키를 두 번 눌러서 자판기 앱을 종료할 경우에는 archive data가 제대로 저장되지 않는 것을 확인하고, `sceneWillResignActive`가 호출될 때에도 데이터를 저장할 수 있도록 추가해서 문제를 해결하였습니다.
