### PR TITLE
[Zeke] Step5 - NotificationCenter와 싱글톤패턴

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,19 @@
 
 - 완성날짜
   - 2021-03-15 17:04
+
+
+
+
+
+## step-5
+
+- 설명
+  - ViewController를 NotificationCenter의 Observer로 등록하였다.
+  - Notification의 Name을 "addStockButton", "rechargeButton"으로 두 가지 생성하였다.
+  - 자판기 객체의 재고가 추가될 때, 잔액이 충전될 때 NotificationCenter로 post하도록 구현하였다.
+
+
+
+- 완성날짜
+  - 2021-03-17

--- a/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
+++ b/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		B3B3DD3525E7EF620022465D /* CashManagementSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B3DD3425E7EF620022465D /* CashManagementSystem.swift */; };
 		B3B6E92325FB3A53002F2920 /* Archiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B6E92225FB3A53002F2920 /* Archiver.swift */; };
 		B3CEBECC2600557200DD08A2 /* NotificationName.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3CEBECB2600557200DD08A2 /* NotificationName.swift */; };
+		B3CEBED026005A0A00DD08A2 /* BeverageData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3CEBECF26005A0A00DD08A2 /* BeverageData.swift */; };
+		B3CEBED426005A1A00DD08A2 /* RechargeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3CEBED326005A1A00DD08A2 /* RechargeData.swift */; };
 		B3EF2CE725EE1B5B00FBA7CC /* VendingMachineAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3EF2CE625EE1B5B00FBA7CC /* VendingMachineAppTests.swift */; };
 		B3EF2CF025EE227C00FBA7CC /* VendingMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = B36A87D325E62EAB002C4432 /* VendingMachine.swift */; };
 		B3EF2CF125EE227C00FBA7CC /* CashManagementSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B3DD3425E7EF620022465D /* CashManagementSystem.swift */; };
@@ -82,6 +84,8 @@
 		B3B3DD3425E7EF620022465D /* CashManagementSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CashManagementSystem.swift; sourceTree = "<group>"; };
 		B3B6E92225FB3A53002F2920 /* Archiver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Archiver.swift; sourceTree = "<group>"; };
 		B3CEBECB2600557200DD08A2 /* NotificationName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationName.swift; sourceTree = "<group>"; };
+		B3CEBECF26005A0A00DD08A2 /* BeverageData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeverageData.swift; sourceTree = "<group>"; };
+		B3CEBED326005A1A00DD08A2 /* RechargeData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RechargeData.swift; sourceTree = "<group>"; };
 		B3EF2CE425EE1B5B00FBA7CC /* VendingMachineAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = VendingMachineAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B3EF2CE625EE1B5B00FBA7CC /* VendingMachineAppTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VendingMachineAppTests.swift; sourceTree = "<group>"; };
 		B3EF2CE825EE1B5B00FBA7CC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -134,6 +138,8 @@
 		B36A87A425E61B84002C4432 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				B3CEBECF26005A0A00DD08A2 /* BeverageData.swift */,
+				B3CEBED326005A1A00DD08A2 /* RechargeData.swift */,
 				B36A87D325E62EAB002C4432 /* VendingMachine.swift */,
 				B3B3DD3425E7EF620022465D /* CashManagementSystem.swift */,
 				B36A87D825E636B7002C4432 /* Drinks.swift */,
@@ -376,6 +382,7 @@
 				B36A87D425E62EAB002C4432 /* VendingMachine.swift in Sources */,
 				B3FC892F25EBEA1500E70D38 /* RedBull.swift in Sources */,
 				B36A87AA25E61BA1002C4432 /* Soda.swift in Sources */,
+				B3CEBED026005A0A00DD08A2 /* BeverageData.swift in Sources */,
 				B36A87B625E62256002C4432 /* StrawberryMilk.swift in Sources */,
 				B36A87C125E6232E002C4432 /* TOP.swift in Sources */,
 				B3F5728A25E3629300CFF095 /* ViewController.swift in Sources */,
@@ -383,6 +390,7 @@
 				B36A87D925E636B7002C4432 /* Drinks.swift in Sources */,
 				B3B3DD3525E7EF620022465D /* CashManagementSystem.swift in Sources */,
 				B36A87B125E61F1B002C4432 /* Beverage.swift in Sources */,
+				B3CEBED426005A1A00DD08A2 /* RechargeData.swift in Sources */,
 				B32ECEA825F12B900066C473 /* BeverageFactory.swift in Sources */,
 				B37B9F7225F8B5EE00256032 /* RedBullFactory.swift in Sources */,
 				B37B9F6E25F8B58A00256032 /* StrawberryFactory.swift in Sources */,

--- a/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
+++ b/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		B3B3DD3025E7D8450022465D /* EnergyDrink.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B3DD2F25E7D8450022465D /* EnergyDrink.swift */; };
 		B3B3DD3525E7EF620022465D /* CashManagementSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B3DD3425E7EF620022465D /* CashManagementSystem.swift */; };
 		B3B6E92325FB3A53002F2920 /* Archiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B6E92225FB3A53002F2920 /* Archiver.swift */; };
+		B3CEBECC2600557200DD08A2 /* NotificationName.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3CEBECB2600557200DD08A2 /* NotificationName.swift */; };
 		B3EF2CE725EE1B5B00FBA7CC /* VendingMachineAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3EF2CE625EE1B5B00FBA7CC /* VendingMachineAppTests.swift */; };
 		B3EF2CF025EE227C00FBA7CC /* VendingMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = B36A87D325E62EAB002C4432 /* VendingMachine.swift */; };
 		B3EF2CF125EE227C00FBA7CC /* CashManagementSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B3DD3425E7EF620022465D /* CashManagementSystem.swift */; };
@@ -80,6 +81,7 @@
 		B3B3DD2F25E7D8450022465D /* EnergyDrink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnergyDrink.swift; sourceTree = "<group>"; };
 		B3B3DD3425E7EF620022465D /* CashManagementSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CashManagementSystem.swift; sourceTree = "<group>"; };
 		B3B6E92225FB3A53002F2920 /* Archiver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Archiver.swift; sourceTree = "<group>"; };
+		B3CEBECB2600557200DD08A2 /* NotificationName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationName.swift; sourceTree = "<group>"; };
 		B3EF2CE425EE1B5B00FBA7CC /* VendingMachineAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = VendingMachineAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B3EF2CE625EE1B5B00FBA7CC /* VendingMachineAppTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VendingMachineAppTests.swift; sourceTree = "<group>"; };
 		B3EF2CE825EE1B5B00FBA7CC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -124,6 +126,7 @@
 			isa = PBXGroup;
 			children = (
 				B36A87DC25E63E14002C4432 /* Date.swift */,
+				B3CEBECB2600557200DD08A2 /* NotificationName.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -368,6 +371,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B3B6E92325FB3A53002F2920 /* Archiver.swift in Sources */,
+				B3CEBECC2600557200DD08A2 /* NotificationName.swift in Sources */,
 				B36A87C425E6233C002C4432 /* Cola.swift in Sources */,
 				B36A87D425E62EAB002C4432 /* VendingMachine.swift in Sources */,
 				B3FC892F25EBEA1500E70D38 /* RedBull.swift in Sources */,

--- a/VendingMachineApp/VendingMachineApp/AppDelegate.swift
+++ b/VendingMachineApp/VendingMachineApp/AppDelegate.swift
@@ -10,15 +10,10 @@ import UIKit
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     
-    var vendingMachine: VendingMachine?
-    
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
-        if vendingMachine == nil {
-            vendingMachine = VendingMachine()
-        }
         
         if let savedData = UserDefaults.standard.object(forKey: "vendingMachine") {
-            vendingMachine = Archiver.unarchive(with: savedData as! Data) as! VendingMachine
+            VendingMachine.shared = Archiver.unarchive(with: savedData as! Data) as! VendingMachine
         }
         return true
     }

--- a/VendingMachineApp/VendingMachineApp/AppDelegate.swift
+++ b/VendingMachineApp/VendingMachineApp/AppDelegate.swift
@@ -10,13 +10,17 @@ import UIKit
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     
-    var vendingMachine = VendingMachine()
+    var vendingMachine: VendingMachine?
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+        if vendingMachine == nil {
+            vendingMachine = VendingMachine()
+        }
+        
         if let savedData = UserDefaults.standard.object(forKey: "vendingMachine") {
             vendingMachine = Archiver.unarchive(with: savedData as! Data) as! VendingMachine
         }
         return true
-    }    
+    }
 }
 

--- a/VendingMachineApp/VendingMachineApp/Archiver.swift
+++ b/VendingMachineApp/VendingMachineApp/Archiver.swift
@@ -8,14 +8,13 @@
 import Foundation
 
 class Archiver {
-    static func archive(with things: Any) -> Data {
+    static func archive(with things: Any) -> Data? {
         do {
             let data = try NSKeyedArchiver.archivedData(withRootObject: things, requiringSecureCoding: false)
             return data
         } catch {
-            print(error)
+            return nil
         }
-        return Data()
     }
     
     static func unarchive(with things: Data) -> Any? {
@@ -23,8 +22,7 @@ class Archiver {
             let object = try NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(things)
             return object
         } catch {
-            print(error)
+            return nil
         }
-        return nil
     }
 }

--- a/VendingMachineApp/VendingMachineApp/Controller/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/Controller/ViewController.swift
@@ -15,30 +15,29 @@ class ViewController: UIViewController {
     @IBOutlet var beverageLabels: [UILabel]!
     @IBOutlet var rechargeButtons: [UIButton]!
     
-    var vendingMachine: VendingMachinable?
+    var vendingMachine = VendingMachine.shared
     var beverageData = BeverageData()
     var rechargeData = RechargeData()
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         curveImageVertex()
         beverageData.setUp(buttons: beverageButtons, labels: beverageLabels)
-        rechargeData.setUP(buttons: beverageButtons)
+        rechargeData.setUP(buttons: rechargeButtons)
         loadSavedLabel()
-        NotificationCenter.default.addObserver(self, selector: #selector(updateBeverageLabel), name: .addStockButton, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(updateRechargeLabel), name: .rechargeButton, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(updateBeverageLabel), name: .addStockButton, object: self)
+        NotificationCenter.default.addObserver(self, selector: #selector(updateRechargeLabel), name: .rechargeButton, object: self)
     }
     
     @IBAction func addStock(_ sender: UIButton) {
         guard let type = beverageData.showType(with: sender) else { return }
         guard let product = BeverageFactory.releaseBeverage(with: type) else { return }
-        vendingMachine?.addStock(as: product)
+        vendingMachine.addStock(as: product)
     }
     
     @IBAction func rechargeCash(_ sender: UIButton) {
         guard let cash = rechargeData.showCash(with: sender)?.rawValue else { return }
-        print(cash)
-        vendingMachine?.rechargeCash(with: cash)
+        vendingMachine.rechargeCash(with: cash)
     }
     
     func curveImageVertex() {
@@ -48,33 +47,29 @@ class ViewController: UIViewController {
         }
     }
     
-    @objc
     func loadSavedLabel() {
         for button in beverageButtons {
             guard let type = beverageData.showType(with: button), let label = beverageData.showLabel(sender: button) else { return }
-            guard let stock = vendingMachine?.showStock()[ObjectIdentifier(type)] else { return }
-            label.text = "\(stock.count)개"
+            let stock = vendingMachine.showStock()[ObjectIdentifier(type)]
+            label.text = "\(stock?.count ?? 0)개"
         }
-        guard let money = vendingMachine?.showBalance() else { return }
+        let money = vendingMachine.showBalance()
         balanceLabel.text = "\(money)원"
     }
     
     @objc
     func updateBeverageLabel(_ notification: Notification) {
-        let updateObject = notification.object as! VendingMachinable
-        self.vendingMachine = updateObject
         for button in beverageButtons {
-            guard let type = beverageData.showType(with: button), let label = beverageData.showLabel(sender: button) else { return }
-            guard let stock = vendingMachine?.showStock()[ObjectIdentifier(type)] else { return }
-            label.text = "\(stock.count)개"
+            guard let type = beverageData.showType(with: button) else { return }
+            guard let label = beverageData.showLabel(sender: button) else { return }
+            let stock = vendingMachine.showStock()[ObjectIdentifier(type)]
+            label.text = "\(stock?.count ?? 0)개"
         }
     }
     
     @objc
     func updateRechargeLabel(_ notification: Notification) {
-        let updateObject = notification.object as! VendingMachinable
-        self.vendingMachine = updateObject
-        guard let money = vendingMachine?.showBalance() else { return }
+        let money = vendingMachine.showBalance()
         balanceLabel.text = "\(money)원"
     }
 }

--- a/VendingMachineApp/VendingMachineApp/Controller/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/Controller/ViewController.swift
@@ -15,19 +15,18 @@ class ViewController: UIViewController {
     @IBOutlet var beverageLabels: [UILabel]!
     @IBOutlet var rechargeButtons: [UIButton]!
     
-    let appDelegate = UIApplication.shared.delegate as! AppDelegate
-    var vendingMachine: VendingMachine?
+    var vendingMachine: VendingMachinable?
     var beverageData = BeverageData()
     var rechargeData = RechargeData()
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.vendingMachine = appDelegate.vendingMachine
         curveImageVertex()
         beverageData.setUp(buttons: beverageButtons, labels: beverageLabels)
         rechargeData.setUP(buttons: beverageButtons)
         loadSavedLabel()
-        NotificationCenter.default.addObserver(self, selector: #selector(loadSavedLabel), name: .vendingMachineNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(updateBeverageLabel), name: .addStockButton, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(updateRechargeLabel), name: .rechargeButton, object: nil)
     }
     
     @IBAction func addStock(_ sender: UIButton) {
@@ -38,6 +37,7 @@ class ViewController: UIViewController {
     
     @IBAction func rechargeCash(_ sender: UIButton) {
         guard let cash = rechargeData.showCash(with: sender)?.rawValue else { return }
+        print(cash)
         vendingMachine?.rechargeCash(with: cash)
     }
     
@@ -58,5 +58,23 @@ class ViewController: UIViewController {
         guard let money = vendingMachine?.showBalance() else { return }
         balanceLabel.text = "\(money)원"
     }
+    
+    @objc
+    func updateBeverageLabel(_ notification: Notification) {
+        let updateObject = notification.object as! VendingMachinable
+        self.vendingMachine = updateObject
+        for button in beverageButtons {
+            guard let type = beverageData.showType(with: button), let label = beverageData.showLabel(sender: button) else { return }
+            guard let stock = vendingMachine?.showStock()[ObjectIdentifier(type)] else { return }
+            label.text = "\(stock.count)개"
+        }
+    }
+    
+    @objc
+    func updateRechargeLabel(_ notification: Notification) {
+        let updateObject = notification.object as! VendingMachinable
+        self.vendingMachine = updateObject
+        guard let money = vendingMachine?.showBalance() else { return }
+        balanceLabel.text = "\(money)원"
+    }
 }
-

--- a/VendingMachineApp/VendingMachineApp/Controller/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/Controller/ViewController.swift
@@ -17,28 +17,27 @@ class ViewController: UIViewController {
     
     let appDelegate = UIApplication.shared.delegate as! AppDelegate
     var vendingMachine: VendingMachine?
-    var dataOfBeverageButton: [UIButton : (beverageType: Beverage.Type, label: UILabel)] = [:]
-    var dataOfRechargeButton: [UIButton : CashManagementSystem.SelectCash] = [:]
-    let beveragesType = [Cola.self, RedBull.self, StrawBerryMilk.self, TOP.self]
+    var beverageData = BeverageData()
+    var rechargeData = RechargeData()
 
     override func viewDidLoad() {
         super.viewDidLoad()
         self.vendingMachine = appDelegate.vendingMachine
         curveImageVertex()
-        fillDataOfBeverageButton()
-        fillDataOfRechargeButton()
+        beverageData.setUp(buttons: beverageButtons, labels: beverageLabels)
+        rechargeData.setUP(buttons: beverageButtons)
         loadSavedLabel()
         NotificationCenter.default.addObserver(self, selector: #selector(loadSavedLabel), name: .vendingMachineNotification, object: nil)
     }
     
     @IBAction func addStock(_ sender: UIButton) {
-        guard let type = dataOfBeverageButton[sender]?.beverageType else { return }
+        guard let type = beverageData.showType(with: sender) else { return }
         guard let product = BeverageFactory.releaseBeverage(with: type) else { return }
         vendingMachine?.addStock(as: product)
     }
     
     @IBAction func rechargeCash(_ sender: UIButton) {
-        guard let cash = dataOfRechargeButton[sender]?.rawValue else { return }
+        guard let cash = rechargeData.showCash(with: sender)?.rawValue else { return }
         vendingMachine?.rechargeCash(with: cash)
     }
     
@@ -46,12 +45,6 @@ class ViewController: UIViewController {
         beverageImages.forEach{ (imageView) in
             imageView.layer.cornerRadius = 50
             imageView.clipsToBounds = true
-        }
-    }
-    
-    func fillDataOfBeverageButton() {
-        for i in 0...3 {
-            dataOfBeverageButton[beverageButtons[i]] = (beveragesType[i], beverageLabels[i])
         }
     }
     
@@ -65,11 +58,5 @@ class ViewController: UIViewController {
         guard let money = vendingMachine?.showBalance() else { return }
         balanceLabel.text = "\(money)원"
     }
-    
-    func fillDataOfRechargeButton() {
-        dataOfRechargeButton[rechargeButtons[0]] = CashManagementSystem.SelectCash.thousand
-        dataOfRechargeButton[rechargeButtons[1]] = CashManagementSystem.SelectCash.fiveThousands
-    }
-    
 }
 

--- a/VendingMachineApp/VendingMachineApp/Controller/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/Controller/ViewController.swift
@@ -18,7 +18,7 @@ class ViewController: UIViewController {
     let appDelegate = UIApplication.shared.delegate as! AppDelegate
     var vendingMachine: VendingMachine?
     var dataOfBeverageButton: [UIButton : (beverageType: Beverage.Type, label: UILabel)] = [:]
-    var dataOfRechargeButton: [UIButton : Int] = [:]
+    var dataOfRechargeButton: [UIButton : CashManagementSystem.SelectCash] = [:]
     let beveragesType = [Cola.self, RedBull.self, StrawBerryMilk.self, TOP.self]
 
     override func viewDidLoad() {
@@ -31,17 +31,17 @@ class ViewController: UIViewController {
     }
     
     @IBAction func addStock(_ sender: UIButton) {
-        guard let type = dataOfBeverageButton[sender]?.beverageType else {return}
-        guard let product = BeverageFactory.releaseBeverage(with: type) else {return}
+        guard let type = dataOfBeverageButton[sender]?.beverageType else { return }
+        guard let product = BeverageFactory.releaseBeverage(with: type) else { return }
         vendingMachine?.addStock(as: product)
         guard let stockList = vendingMachine?.showStock() else { return }
         let beverageID = ObjectIdentifier(type)
-        guard let stock = stockList[beverageID] else {return}
+        guard let stock = stockList[beverageID] else { return }
         dataOfBeverageButton[sender]?.label.text = "\(stock.count)개"
     }
     
     @IBAction func rechargeCash(_ sender: UIButton) {
-        guard let cash = dataOfRechargeButton[sender] else { return }
+        guard let cash = dataOfRechargeButton[sender]?.rawValue else { return }
         vendingMachine?.rechargeCash(with: cash)
         guard let balance = vendingMachine?.showBalance().description else { return }
         balanceLabel.text = "\(balance)원"
@@ -66,13 +66,13 @@ class ViewController: UIViewController {
                 beverageLabels[i].text = "\(stock.count)개"
             }
         }
-        guard let money = vendingMachine?.showBalance() else {return}
+        guard let money = vendingMachine?.showBalance() else { return }
         balanceLabel.text = "\(money)원"
     }
     
     func fillDataOfRechargeButton() {
-        dataOfRechargeButton[rechargeButtons[0]] = 1000
-        dataOfRechargeButton[rechargeButtons[1]] = 5000
+        dataOfRechargeButton[rechargeButtons[0]] = CashManagementSystem.SelectCash.thousand
+        dataOfRechargeButton[rechargeButtons[1]] = CashManagementSystem.SelectCash.fiveThousands
     }
     
 }

--- a/VendingMachineApp/VendingMachineApp/Controller/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/Controller/ViewController.swift
@@ -33,18 +33,18 @@ class ViewController: UIViewController {
     @IBAction func addStock(_ sender: UIButton) {
         guard let type = dataOfBeverageButton[sender]?.beverageType else {return}
         guard let product = BeverageFactory.releaseBeverage(with: type) else {return}
-        vendingMachine!.addStock(as: product)
-        let stockList = vendingMachine!.showStock()
+        vendingMachine?.addStock(as: product)
+        guard let stockList = vendingMachine?.showStock() else { return }
         let beverageID = ObjectIdentifier(type)
         guard let stock = stockList[beverageID] else {return}
         dataOfBeverageButton[sender]?.label.text = "\(stock.count)개"
-        print(vendingMachine!.showStock())
     }
     
     @IBAction func rechargeCash(_ sender: UIButton) {
-        guard let cash = dataOfRechargeButton[sender] else {return}
-        vendingMachine!.rechargeCash(with: cash)
-        balanceLabel.text = "\(vendingMachine!.showBalance().description)원"
+        guard let cash = dataOfRechargeButton[sender] else { return }
+        vendingMachine?.rechargeCash(with: cash)
+        guard let balance = vendingMachine?.showBalance().description else { return }
+        balanceLabel.text = "\(balance)원"
     }
     
     func curveImageVertex() {
@@ -62,7 +62,7 @@ class ViewController: UIViewController {
     
     func loadSavedLabel() {
         for i in 0...3 {
-            if let stock = vendingMachine!.showStock()[ObjectIdentifier(beveragesType[i])] {
+            if let stock = vendingMachine?.showStock()[ObjectIdentifier(beveragesType[i])] {
                 beverageLabels[i].text = "\(stock.count)개"
             }
         }

--- a/VendingMachineApp/VendingMachineApp/Controller/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/Controller/ViewController.swift
@@ -50,10 +50,10 @@ class ViewController: UIViewController {
     
     @objc
     func loadSavedLabel() {
-        for i in 0...3 {
-            if let stock = vendingMachine?.showStock()[ObjectIdentifier(beveragesType[i])] {
-                beverageLabels[i].text = "\(stock.count)개"
-            }
+        for button in beverageButtons {
+            guard let type = beverageData.showType(with: button), let label = beverageData.showLabel(sender: button) else { return }
+            guard let stock = vendingMachine?.showStock()[ObjectIdentifier(type)] else { return }
+            label.text = "\(stock.count)개"
         }
         guard let money = vendingMachine?.showBalance() else { return }
         balanceLabel.text = "\(money)원"

--- a/VendingMachineApp/VendingMachineApp/Controller/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/Controller/ViewController.swift
@@ -28,23 +28,18 @@ class ViewController: UIViewController {
         fillDataOfBeverageButton()
         fillDataOfRechargeButton()
         loadSavedLabel()
+        NotificationCenter.default.addObserver(self, selector: #selector(loadSavedLabel), name: .vendingMachineNotification, object: nil)
     }
     
     @IBAction func addStock(_ sender: UIButton) {
         guard let type = dataOfBeverageButton[sender]?.beverageType else { return }
         guard let product = BeverageFactory.releaseBeverage(with: type) else { return }
         vendingMachine?.addStock(as: product)
-        guard let stockList = vendingMachine?.showStock() else { return }
-        let beverageID = ObjectIdentifier(type)
-        guard let stock = stockList[beverageID] else { return }
-        dataOfBeverageButton[sender]?.label.text = "\(stock.count)개"
     }
     
     @IBAction func rechargeCash(_ sender: UIButton) {
         guard let cash = dataOfRechargeButton[sender]?.rawValue else { return }
         vendingMachine?.rechargeCash(with: cash)
-        guard let balance = vendingMachine?.showBalance().description else { return }
-        balanceLabel.text = "\(balance)원"
     }
     
     func curveImageVertex() {
@@ -60,6 +55,7 @@ class ViewController: UIViewController {
         }
     }
     
+    @objc
     func loadSavedLabel() {
         for i in 0...3 {
             if let stock = vendingMachine?.showStock()[ObjectIdentifier(beveragesType[i])] {

--- a/VendingMachineApp/VendingMachineApp/Extension/NotificationName.swift
+++ b/VendingMachineApp/VendingMachineApp/Extension/NotificationName.swift
@@ -1,0 +1,12 @@
+//
+//  NotificationName.swift
+//  VendingMachineApp
+//
+//  Created by 양준혁 on 2021/03/16.
+//
+
+import Foundation
+
+extension Notification.Name {
+    static let vendingMachineNotification = Notification.Name("vendingMachineNotification")
+}

--- a/VendingMachineApp/VendingMachineApp/Extension/NotificationName.swift
+++ b/VendingMachineApp/VendingMachineApp/Extension/NotificationName.swift
@@ -8,5 +8,7 @@
 import Foundation
 
 extension Notification.Name {
-    static let vendingMachineNotification = Notification.Name("vendingMachineNotification")
+    static let addStockButton = Notification.Name("addStockButton")
+    static let rechargeButton = Notification.Name("rechargeButton")
 }
+

--- a/VendingMachineApp/VendingMachineApp/Model/BeverageData.swift
+++ b/VendingMachineApp/VendingMachineApp/Model/BeverageData.swift
@@ -1,0 +1,30 @@
+//
+//  BeverageData.swift
+//  VendingMachineApp
+//
+//  Created by 양준혁 on 2021/03/16.
+//
+
+import UIKit
+
+class BeverageData {
+    private var data: [UIButton : (beverageType: Beverage.Type, label: UILabel)] = [:]
+    private let beverageTypes = [Cola.self, RedBull.self, StrawBerryMilk.self, TOP.self]
+    
+    func setUp(buttons: [UIButton], labels: [UILabel]) {
+        let labelWithTypeZip = zip(beverageTypes, labels)
+        let viewZip = zip(buttons, labelWithTypeZip)
+        for (button, labelWithType) in viewZip {
+            data[button] = labelWithType
+        }
+    }
+    
+    func showType(with sender: UIButton) -> Beverage.Type? {
+        return data[sender]?.beverageType
+        
+    }
+    
+    func showLabel(sender: UIButton) -> UILabel? {
+        return data[sender]?.label
+    }
+}

--- a/VendingMachineApp/VendingMachineApp/Model/CashManagementSystem.swift
+++ b/VendingMachineApp/VendingMachineApp/Model/CashManagementSystem.swift
@@ -10,6 +10,11 @@ import Foundation
 class CashManagementSystem: NSObject, NSCoding {
     private var cash: Int
     
+    enum SelectCash: Int {
+        case thousand = 1000
+        case fiveThousands = 5000
+    }
+    
     override var description : String {
         return "\(self.cash)"
     }

--- a/VendingMachineApp/VendingMachineApp/Model/RechargeData.swift
+++ b/VendingMachineApp/VendingMachineApp/Model/RechargeData.swift
@@ -1,0 +1,21 @@
+//
+//  RechargeData.swift
+//  VendingMachineApp
+//
+//  Created by 양준혁 on 2021/03/16.
+//
+
+import UIKit
+
+class RechargeData {
+    private var data: [UIButton : CashManagementSystem.SelectCash] = [:]
+    
+    func setUP(buttons: [UIButton]) {
+        data[buttons[0]] = CashManagementSystem.SelectCash.thousand
+        data[buttons[1]] = CashManagementSystem.SelectCash.fiveThousands
+    }
+    
+    func showCash(with sender: UIButton) -> CashManagementSystem.SelectCash? {
+        return data[sender] ?? nil
+    }
+}

--- a/VendingMachineApp/VendingMachineApp/Model/VendingMachine.swift
+++ b/VendingMachineApp/VendingMachineApp/Model/VendingMachine.swift
@@ -33,10 +33,12 @@ class VendingMachine: NSObject, NSCoding {
     
     func addStock(as beverage: Beverage) {
         drinks.add(with: beverage)
+        NotificationCenter.default.post(name: .vendingMachineNotification, object: nil)
     }
 
     func rechargeCash(with cash: Int) {
         cashManagementSystem.increaseCash(with: cash)
+        NotificationCenter.default.post(name: .vendingMachineNotification, object: nil)
     }
     
     func showListForPurchase() -> Drinks {

--- a/VendingMachineApp/VendingMachineApp/Model/VendingMachine.swift
+++ b/VendingMachineApp/VendingMachineApp/Model/VendingMachine.swift
@@ -33,12 +33,12 @@ class VendingMachine: NSObject, NSCoding, VendingMachinable {
     
     func addStock(as beverage: Beverage) {
         drinks.add(with: beverage)
-        NotificationCenter.default.post(name: .vendingMachineNotification, object: nil)
+        NotificationCenter.default.post(name: .addStockButton, object: self)
     }
 
     func rechargeCash(with cash: Int) {
         cashManagementSystem.increaseCash(with: cash)
-        NotificationCenter.default.post(name: .vendingMachineNotification, object: nil)
+        NotificationCenter.default.post(name: .rechargeButton, object: self)
     }
     
     func showListForPurchase() -> Drinks {

--- a/VendingMachineApp/VendingMachineApp/Model/VendingMachine.swift
+++ b/VendingMachineApp/VendingMachineApp/Model/VendingMachine.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class VendingMachine: NSObject, NSCoding {
+class VendingMachine: NSObject, NSCoding, VendingMachinable {
     private var drinks: Drinks
     private var cashManagementSystem: CashManagementSystem
     private var purchasedList: PurchasedList
@@ -71,4 +71,11 @@ class VendingMachine: NSObject, NSCoding {
     func showPurchasedList() -> PurchasedList {
         purchasedList.givePurchasedList()
     }
+}
+
+protocol VendingMachinable {
+    func addStock(as beverage: Beverage)
+    func rechargeCash(with cash: Int)
+    func showStock() -> [ObjectIdentifier:[Beverage]]
+    func showBalance() -> CashManagementSystem
 }

--- a/VendingMachineApp/VendingMachineApp/Model/VendingMachine.swift
+++ b/VendingMachineApp/VendingMachineApp/Model/VendingMachine.swift
@@ -11,6 +11,7 @@ class VendingMachine: NSObject, NSCoding, VendingMachinable {
     private var drinks: Drinks
     private var cashManagementSystem: CashManagementSystem
     private var purchasedList: PurchasedList
+    static var shared = VendingMachine()
     
     override init() {
         self.drinks = Drinks()
@@ -28,17 +29,16 @@ class VendingMachine: NSObject, NSCoding, VendingMachinable {
         drinks = coder.decodeObject(forKey: "drinks") as! Drinks
         cashManagementSystem = coder.decodeObject(forKey: "cashManagementSystem") as! CashManagementSystem
         purchasedList = coder.decodeObject(forKey: "purchasedList") as! PurchasedList
-        
     }
     
     func addStock(as beverage: Beverage) {
         drinks.add(with: beverage)
-        NotificationCenter.default.post(name: .addStockButton, object: self)
+        NotificationCenter.default.post(name: .addStockButton, object: VendingMachine.shared)
     }
 
     func rechargeCash(with cash: Int) {
         cashManagementSystem.increaseCash(with: cash)
-        NotificationCenter.default.post(name: .rechargeButton, object: self)
+        NotificationCenter.default.post(name: .rechargeButton, object: VendingMachine.shared)
     }
     
     func showListForPurchase() -> Drinks {

--- a/VendingMachineApp/VendingMachineApp/SceneDelegate.swift
+++ b/VendingMachineApp/VendingMachineApp/SceneDelegate.swift
@@ -11,7 +11,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
     var vendingMachine = (UIApplication.shared.delegate as! AppDelegate).vendingMachine
 
-    func sceneDidEnterBackground(_ scene: UIScene) {
+    func sceneWillResignActive(_ scene: UIScene) {
         let data = Archiver.archive(with: vendingMachine)
         UserDefaults.standard.setValue(data, forKey: "vendingMachine")
     }

--- a/VendingMachineApp/VendingMachineApp/SceneDelegate.swift
+++ b/VendingMachineApp/VendingMachineApp/SceneDelegate.swift
@@ -9,11 +9,11 @@ import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
-    var vendingMachine = (UIApplication.shared.delegate as! AppDelegate).vendingMachine
-
+    
     func sceneWillResignActive(_ scene: UIScene) {
-        let data = Archiver.archive(with: vendingMachine)
+        guard let data = Archiver.archive(with: VendingMachine.shared) else { return }
         UserDefaults.standard.setValue(data, forKey: "vendingMachine")
+        
     }
 }
 


### PR DESCRIPTION
- ## 작업 목록
  
  - [x] Archiver Class 의 do-catch문 수정
  - [x] 앱 생명주기에 따른 데이터 저장 시점 변경
  - [x] ViewController에 NotificationCenter의 Observer로 등록
  - [x] 자판기 객체의 재고 추가, 잔액 충전 메소드에 NotificationCenter에 post하도록 구현
  - [x] VendingMachinable 프로토콜 생성
  - [x] VendingMachine을 싱글톤으로 구현

 


- ## 학습 키워드

  - NotificationCenter
  - Observer Pattern
  - Singleton Pattern
  - 의존성 역전 (Inversion)
  
  


- ## 고민과 해결

  - 처음에 AppDelegate에 자판기 인스턴스를 생성하는 코드를 구현하여 앱을 실행할 때 마다 자판기 객체가 생성되는 실수를 피드백을 통해 인지하였습니다. 따라서 초기에 불리는 메소드들 didFinishLaunching, SceneConnection, viewDidLoad 등의 순서를 확인하였고 어느 시점에 자판기 객체가 단 한번만 생성되게 해야하는지 확인하고 수정하였습니다.

  - button을 눌렀을 때 음료 인스턴스 증가와 함께 Label 또한 갱신되어야 하지만 Label은 변하지 않았습니다. 이유를 찾아보니 nil값이 포함되었습니다. 찾는 과정에서 `guard`문을 한 메소드안에 여러개 사용하다보니 어디서 exit되는지 nil값이 발견되는지 발견하는 과정에서 오랜 시간이 소요되었습니다. `guard`문을 지우고 강제언래핑을 하면서 하나씩 찾아나가는 과정을 겪었는데 좀 더 빠르고 효율적인 방법에 대해선 아직 고민중입니다. (nil발견이 의심되는 부분을 break찍으면서 탈출하는 지점을 찾을 수도 있겠다 생각이들었습니다.)

  - ViewController에서 상위 AppDelegate에 접근하는 방법을 지양하고자 VendingMachineable 프로토콜을 생성하였지만 AppDelegate에서 ViewController로 프로토콜을 어떻게 사용할지 감이 잡히지 않아 자판기 객체를 싱글톤으로 생성하여 진행하였습니다.

