### PR TITLE
[BMO] Step5 - NotificationCenter를 통한 흐름 분리

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,9 @@
 <p align="center">
 <img width="800" alt="step3" src="https://user-images.githubusercontent.com/45817559/110775848-bd77f400-82a2-11eb-947e-fedc995546cf.gif">
 </p>
+
+# Step 4
+- VendingMachine 변수 AppDelegate로 이동
+- VendingMachine 객체 인스턴스 속성 저장
+- 저장된 데이터를 복원하여 VendingMachine 객체 생성
+- UserDefaults를 사용해 데이터 저장. 저장 시 아카이브를 통해 전 계층 데이터화

--- a/VendinMachineApp/VendinMachineApp.xcodeproj/project.pbxproj
+++ b/VendinMachineApp/VendinMachineApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		CE82B6A72601E0B00093DA61 /* NotificationName.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE82B6A62601E0B00093DA61 /* NotificationName.swift */; };
 		CE91CEB525EE5E8600515DF2 /* ChocoMilk.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE91CEB425EE5E8600515DF2 /* ChocoMilk.swift */; };
 		CE91CEB825EEA5B400515DF2 /* Country.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE91CEB725EEA5B400515DF2 /* Country.swift */; };
 		CE91CEC025EF329900515DF2 /* BeverageProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE91CEBF25EF329900515DF2 /* BeverageProtocol.swift */; };
@@ -65,6 +66,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		CE82B6A62601E0B00093DA61 /* NotificationName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationName.swift; sourceTree = "<group>"; };
 		CE91CEB425EE5E8600515DF2 /* ChocoMilk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChocoMilk.swift; sourceTree = "<group>"; };
 		CE91CEB725EEA5B400515DF2 /* Country.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Country.swift; sourceTree = "<group>"; };
 		CE91CEBF25EF329900515DF2 /* BeverageProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeverageProtocol.swift; sourceTree = "<group>"; };
@@ -159,6 +161,7 @@
 				CE91CEB725EEA5B400515DF2 /* Country.swift */,
 				CE91CEBF25EF329900515DF2 /* BeverageProtocol.swift */,
 				CE9BED3F25F1D213000D6ADB /* BeverageFactory.swift */,
+				CE82B6A62601E0B00093DA61 /* NotificationName.swift */,
 				CE95482625E974350020A333 /* Beverages */,
 			);
 			path = Model;
@@ -294,6 +297,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CE91CEC825EF590100515DF2 /* Latte.swift in Sources */,
+				CE82B6A72601E0B00093DA61 /* NotificationName.swift in Sources */,
 				CE91CECB25EF5B5100515DF2 /* Beverages.swift in Sources */,
 				CE91CEB825EEA5B400515DF2 /* Country.swift in Sources */,
 				CE95481925E7EC840020A333 /* Soda.swift in Sources */,

--- a/VendinMachineApp/VendinMachineApp.xcodeproj/project.pbxproj
+++ b/VendinMachineApp/VendinMachineApp.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		CE9BED6D25F20BDE000D6ADB /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9547FC25E76D5E0020A333 /* ViewController.swift */; };
 		CE9BED7125F217A6000D6ADB /* BeveragesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9BED7025F217A6000D6ADB /* BeveragesTests.swift */; };
 		CE9BED7B25F21B61000D6ADB /* VendingMachineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9BED7A25F21B61000D6ADB /* VendingMachineTests.swift */; };
+		CECDA38E2600FE2700572EA7 /* ArchiveManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CECDA38D2600FE2700572EA7 /* ArchiveManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -94,6 +95,7 @@
 		CE9BED4B25F207B5000D6ADB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		CE9BED7025F217A6000D6ADB /* BeveragesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeveragesTests.swift; sourceTree = "<group>"; };
 		CE9BED7A25F21B61000D6ADB /* VendingMachineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VendingMachineTests.swift; sourceTree = "<group>"; };
+		CECDA38D2600FE2700572EA7 /* ArchiveManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -152,6 +154,7 @@
 			children = (
 				CE95481F25E7F0F10020A333 /* VendingMachine.swift */,
 				CE93BBE325F7979F00C9C374 /* VendingMachineElements.swift */,
+				CECDA38D2600FE2700572EA7 /* ArchiveManager.swift */,
 				CE95482325E9611D0020A333 /* DateExtension.swift */,
 				CE91CEB725EEA5B400515DF2 /* Country.swift */,
 				CE91CEBF25EF329900515DF2 /* BeverageProtocol.swift */,
@@ -310,6 +313,7 @@
 				CE9BED4025F1D213000D6ADB /* BeverageFactory.swift in Sources */,
 				CE95481C25E7ECDC0020A333 /* Coffee.swift in Sources */,
 				CE95482025E7F0F10020A333 /* VendingMachine.swift in Sources */,
+				CECDA38E2600FE2700572EA7 /* ArchiveManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/VendinMachineApp/VendinMachineApp/AppDelegate.swift
+++ b/VendinMachineApp/VendinMachineApp/AppDelegate.swift
@@ -12,32 +12,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var vendingMachine = VendingMachine()
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
-        if let data = UserDefaults.standard.data(forKey: "vendingMachine3"), let vendingMachineDate = unarchive(with: data) {
+        if let data = UserDefaults.standard.data(forKey: "vendingMachine3"), let vendingMachineDate = ArchiveManager.unarchive(with: data) {
             vendingMachine = vendingMachineDate
         }
         return true
     }
     
-    func archive(with things: VendingMachine) -> Data {
-        do {
-            let archived = try NSKeyedArchiver.archivedData(withRootObject: things, requiringSecureCoding: false)
-            return archived
-        }
-        catch {
-            print(error)
-        }
-        return Data()
-    }
-    
-    func unarchive(with things: Data) -> VendingMachine? {
-        do {
-            let object = try NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(things)
-            return object as? VendingMachine
-        }
-        catch {
-            print(error)
-        }
-        return nil
-    }
+
 }
 

--- a/VendinMachineApp/VendinMachineApp/Model/ArchiveManager.swift
+++ b/VendinMachineApp/VendinMachineApp/Model/ArchiveManager.swift
@@ -1,0 +1,27 @@
+
+import Foundation
+
+class ArchiveManager {
+    
+    static func archive(with things: VendingMachine) -> Data {
+        do {
+            let archived = try NSKeyedArchiver.archivedData(withRootObject: things, requiringSecureCoding: false)
+            return archived
+        }
+        catch {
+            print(error)
+            return Data()
+        }
+    }
+    
+    static func unarchive(with things: Data) -> VendingMachine? {
+        do {
+            let object = try NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(things)
+            return object as? VendingMachine
+        }
+        catch {
+            print(error)
+            return nil
+        }
+    }
+}

--- a/VendinMachineApp/VendinMachineApp/Model/Beverages/Beverage.swift
+++ b/VendinMachineApp/VendinMachineApp/Model/Beverages/Beverage.swift
@@ -52,11 +52,12 @@ extension Beverage {
             lhs.price == rhs.price && lhs.name == rhs.name
     }
     
-//    func hash(into hasher: inout Hasher) {
-//        hasher.combine(brand)
-//        hasher.combine(size)
-//        hasher.combine(price)
-//        hasher.combine(name)
-//    }
-    
+    override var hash: Int {
+        var hasher = Hasher()
+        hasher.combine(self.brand)
+        hasher.combine(self.size)
+        hasher.combine(self.price)
+        hasher.combine(self.name)
+        return hasher.finalize()
+    }
 }

--- a/VendinMachineApp/VendinMachineApp/Model/NotificationName.swift
+++ b/VendinMachineApp/VendinMachineApp/Model/NotificationName.swift
@@ -1,0 +1,7 @@
+
+import Foundation
+
+extension Notification.Name {
+    static let insertCash = Notification.Name("insertCash")
+    static let addBeverageStock = Notification.Name("addBeverageStock")
+}

--- a/VendinMachineApp/VendinMachineApp/Model/VendingMachine.swift
+++ b/VendinMachineApp/VendinMachineApp/Model/VendingMachine.swift
@@ -11,6 +11,11 @@ class VendingMachine : NSObject, NSCoding {
         case insertMoney5000 = 5000
     }
     
+    enum NotificationUserInfo {
+        case cashBox
+        case beverageStock
+    }
+    
     override init() {
         cashBox = 0
         beverages = Beverages()
@@ -53,6 +58,7 @@ class VendingMachine : NSObject, NSCoding {
     
     func insertCash(amount: Int) {
         self.cashBox += amount
+        NotificationCenter.default.post(name: .insertCash, object: self, userInfo: [NotificationUserInfo.cashBox :self.cashBox])
     }
     
     func reduceCash(amount: Int) {
@@ -61,6 +67,7 @@ class VendingMachine : NSObject, NSCoding {
     
     func addBeverageStock(_ beverage: Beverage) {
         self.beverages.addBeverage(element: beverage)
+        NotificationCenter.default.post(name: .addBeverageStock, object: self, userInfo: [NotificationUserInfo.beverageStock :totalBeverageStockList()])
     }
     
     func totalBeverageStockList() -> Beverages {

--- a/VendinMachineApp/VendinMachineApp/Model/VendingMachine.swift
+++ b/VendinMachineApp/VendinMachineApp/Model/VendingMachine.swift
@@ -1,15 +1,15 @@
 
 import Foundation
 
-enum VendingMachineMoney : Int, CaseIterable {
-    case insertMoneyType1 = 1000
-    case insertMoneyType2 = 5000
-}
-
 class VendingMachine : NSObject, NSCoding {
     private(set) var cashBox: Int
-    private(set) var beverages: Beverages
-    private(set) var shoppingHistoryData: Beverages
+    private var beverages: Beverages
+    private var shoppingHistoryData: Beverages
+    
+    enum VendingMachineMoney : Int, CaseIterable {
+        case insertMoney1000 = 1000
+        case insertMoney5000 = 5000
+    }
     
     override init() {
         cashBox = 0

--- a/VendinMachineApp/VendinMachineApp/Model/VendingMachineElements.swift
+++ b/VendinMachineApp/VendinMachineApp/Model/VendingMachineElements.swift
@@ -37,7 +37,7 @@ class VendingMachineElements {
     }
     
     func setUpInsertCashButtons(collection: [UIButton]) {
-        for (button, money) in zip(collection, VendingMachineMoney.allCases) {
+        for (button, money) in zip(collection, VendingMachine.VendingMachineMoney.allCases) {
             insertCashButtons.updateValue(money.rawValue, forKey: button)
         }
     }
@@ -52,11 +52,9 @@ class VendingMachineElements {
         }
     }
     
-    func setUpAll(images: [UIImageView], beverageButtons: [UIButton], beverageStockLabels: [UILabel], beverageStock: Beverages, cashButtons: [UIButton], cashLabel: UILabel, cashBox: Int) {
+    func setUpAll(images: [UIImageView], beverageButtons: [UIButton], cashButtons: [UIButton]) {
         self.setUpBeverageImages(collection: images)
         self.setUpInsertCashButtons(collection: cashButtons)
         self.setUpAddBeverageButtons(collection: beverageButtons)
-        self.updateCurrentCash(label: cashLabel, cashBox: cashBox)
-        self.updateBeverageStock(labels: beverageStockLabels, beverageStock: beverageStock)
     }
 }

--- a/VendinMachineApp/VendinMachineApp/SceneDelegate.swift
+++ b/VendinMachineApp/VendinMachineApp/SceneDelegate.swift
@@ -13,7 +13,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var appDelegate = UIApplication.shared.delegate as! AppDelegate
     
     func sceneDidEnterBackground(_ scene: UIScene) {
-        let data = appDelegate.archive(with: appDelegate.vendingMachine)
+        let data = ArchiveManager.archive(with: appDelegate.vendingMachine)
         UserDefaults.standard.set(data, forKey: "vendingMachine3")
     }
 }

--- a/VendinMachineApp/VendinMachineApp/ViewController.swift
+++ b/VendinMachineApp/VendinMachineApp/ViewController.swift
@@ -22,6 +22,9 @@ class ViewController: UIViewController {
  
         NotificationCenter.default.addObserver(self, selector: #selector(updateCurrentCash(notification:)), name: .insertCash, object: appDelegate.vendingMachine)
         NotificationCenter.default.addObserver(self, selector: #selector(updateBeverageStock(notification:)), name: .addBeverageStock, object: appDelegate.vendingMachine)
+        
+        updateCurrentCash(label: cashLabel, cashBox: appDelegate.vendingMachine.cashBox)
+        updateBeverageStock(labels: beverageStockLabels, beverageStock: appDelegate.vendingMachine.totalBeverageStockList(), beverageTypeList: vendingMachineElements.beverageList)
     }
     
     @IBAction func beverageMake(_ sender: UIButton) {
@@ -53,6 +56,17 @@ class ViewController: UIViewController {
             }
         }
     }
+    
+    func updateCurrentCash(label: UILabel, cashBox: Int) {
+        label.text = "\(cashBox)"
+    }
+    
+    func updateBeverageStock(labels: [UILabel], beverageStock: Beverages, beverageTypeList: [Beverage.Type]) {
+        for (beverageLabel, beverageType) in zip(labels, beverageTypeList) {
+            beverageLabel.text = "\(beverageStock.beverageCount(elementType: beverageType))"
+        }
+    }
+
 }
 
 

--- a/VendinMachineApp/VendinMachineApp/ViewController.swift
+++ b/VendinMachineApp/VendinMachineApp/ViewController.swift
@@ -18,7 +18,9 @@ class ViewController: UIViewController {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
         
-        vendingMachineElements.setUpAll(images: beverageImages, beverageButtons: beverageAddButtons, beverageStockLabels: beverageStockLabels, beverageStock: appDelegate.vendingMachine.totalBeverageStockList(), cashButtons: cashButtons, cashLabel: cashLabel, cashBox: appDelegate.vendingMachine.cashBox)
+        vendingMachineElements.setUpAll(images: beverageImages, beverageButtons: beverageAddButtons, cashButtons: cashButtons)
+        updateCurrentCash(label: cashLabel, cashBox: appDelegate.vendingMachine.cashBox)
+        updateBeverageStock(labels: beverageStockLabels, beverageStock: appDelegate.vendingMachine.totalBeverageStockList(), beverageTypeList: vendingMachineElements.beverageList)
     }
     
     @IBAction func beverageMake(_ sender: UIButton) {
@@ -38,6 +40,15 @@ class ViewController: UIViewController {
         vendingMachineElements.updateCurrentCash(label: cashLabel, cashBox: appDelegate.vendingMachine.cashBox)
     }
     
+    func updateCurrentCash(label: UILabel, cashBox: Int) {
+        label.text = "\(cashBox)"
+    }
+    
+    func updateBeverageStock(labels: [UILabel], beverageStock: Beverages, beverageTypeList: [Beverage.Type]) {
+        for (beverageLabel, beverageType) in zip(labels, beverageTypeList) {
+            beverageLabel.text = "\(beverageStock.beverageCount(elementType: beverageType))"
+        }
+    }
 }
 
 

--- a/VendinMachineApp/VendinMachineApp/ViewController.swift
+++ b/VendinMachineApp/VendinMachineApp/ViewController.swift
@@ -19,8 +19,9 @@ class ViewController: UIViewController {
         // Do any additional setup after loading the view.
         
         vendingMachineElements.setUpAll(images: beverageImages, beverageButtons: beverageAddButtons, cashButtons: cashButtons)
-        updateCurrentCash(label: cashLabel, cashBox: appDelegate.vendingMachine.cashBox)
-        updateBeverageStock(labels: beverageStockLabels, beverageStock: appDelegate.vendingMachine.totalBeverageStockList(), beverageTypeList: vendingMachineElements.beverageList)
+ 
+        NotificationCenter.default.addObserver(self, selector: #selector(updateCurrentCash(notification:)), name: .insertCash, object: appDelegate.vendingMachine)
+        NotificationCenter.default.addObserver(self, selector: #selector(updateBeverageStock(notification:)), name: .addBeverageStock, object: appDelegate.vendingMachine)
     }
     
     @IBAction func beverageMake(_ sender: UIButton) {
@@ -37,16 +38,19 @@ class ViewController: UIViewController {
             return
         }
         appDelegate.vendingMachine.insertCash(amount: cash)
-        vendingMachineElements.updateCurrentCash(label: cashLabel, cashBox: appDelegate.vendingMachine.cashBox)
+    }
+
+    @objc func updateCurrentCash(notification: Notification) {
+        if let cash = notification.userInfo?[VendingMachine.NotificationUserInfo.cashBox] as? Int {
+            cashLabel.text = "\(cash)"
+        }
     }
     
-    func updateCurrentCash(label: UILabel, cashBox: Int) {
-        label.text = "\(cashBox)"
-    }
-    
-    func updateBeverageStock(labels: [UILabel], beverageStock: Beverages, beverageTypeList: [Beverage.Type]) {
-        for (beverageLabel, beverageType) in zip(labels, beverageTypeList) {
-            beverageLabel.text = "\(beverageStock.beverageCount(elementType: beverageType))"
+    @objc func updateBeverageStock(notification: Notification) {
+        if let totalBeverages = notification.userInfo?[VendingMachine.NotificationUserInfo.beverageStock] as? Beverages {
+            for (beverageLabel, beverageType) in zip(beverageStockLabels, vendingMachineElements.beverageList) {
+                beverageLabel.text = "\(totalBeverages.beverageCount(elementType: beverageType))"
+            }
         }
     }
 }


### PR DESCRIPTION
### 작업 목록
- [x] viewDidLoad에서 Observer 등록
- [x] vendingMachine 객체에서 모델 변화에 대한 Notification Post
- [x] 삭제했던 Beverage의 hash 재생성

### 학습 키워드
Observer Pattern
NotificationCenter
NSObject hash override
Observer를 통한 MVC 흐름

### 고민과 해결
- Model에서 post를 보낼 때, UserInfo를 사용해 데이터를 보내는게 좋은지 아니면 보낸 객체를 통해 데이터를 가져오는게 좋은지 고민했습니다. object에 데이터가 있어서 UserInfo를 사용하지 말까 생각을 했지만, UserInfo가 있다는 것이 데이터를 보내기 위한 것이라고 생각해서 이를 통해 데이터를 보내는 방법을 택했습니다.
- Notification을 적용할 시 버튼을 눌러 신호를 보내야만 화면의 재고와 돈이 갱신되었고, 앱을 초기 실행했을 때는 제대로 표시되지 않았습니다. 따라서 Notification을 적용하면서 삭제했던 update 메소드를 재생성해서 viewDidLoad에서 실행 시 한 번 화면을 초기화 해주도록 했습니다. 이를 적용하니 update하는 메소드가 중복으로 생성된 것 같아서 AppDelegate에서 update하는 post를 보내볼 까 생각을 했지만, AppDelegate -> SceneDelegate -> viewController 순으로 생성되기에 적용이 되지 않을 것 같아서 기존의 방법을 택했습니다.