### PR TITLE
[ZG] Step5, 6 Notification의 활용, Scroll View 이미지 추가

### DIFF
--- a/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
+++ b/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
@@ -26,6 +26,9 @@
 		827542D525F07DBA0036DDAA /* CaffeLatte.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8272F9D325F04194008167CE /* CaffeLatte.swift */; };
 		827542D825F07DC10036DDAA /* Monster.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8272F9C525F0413E008167CE /* Monster.swift */; };
 		827542DB25F07DC40036DDAA /* Hot6.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8272F9C925F0414B008167CE /* Hot6.swift */; };
+		82820816260306D200615ED1 /* StockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82820815260306D200615ED1 /* StockView.swift */; };
+		828B37862603A9BE0043B93A /* MoneyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828B37852603A9BE0043B93A /* MoneyView.swift */; };
+		828B378C2603BC110043B93A /* BoughtView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828B378B2603BC110043B93A /* BoughtView.swift */; };
 		828EB06525EFD1BD00EC132C /* VendingMachineAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828EB06425EFD1BD00EC132C /* VendingMachineAppTests.swift */; };
 		828EB07325EFD24100EC132C /* VendingMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 829C787E25E7C8B1007C4A68 /* VendingMachine.swift */; };
 		828EB07625EFD24600EC132C /* Beverage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 829C786F25E7C2CB007C4A68 /* Beverage.swift */; };
@@ -77,6 +80,9 @@
 		8272F9C925F0414B008167CE /* Hot6.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Hot6.swift; sourceTree = "<group>"; };
 		8272F9CD25F0418B008167CE /* CaffeMocha.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaffeMocha.swift; sourceTree = "<group>"; };
 		8272F9D325F04194008167CE /* CaffeLatte.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaffeLatte.swift; sourceTree = "<group>"; };
+		82820815260306D200615ED1 /* StockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockView.swift; sourceTree = "<group>"; };
+		828B37852603A9BE0043B93A /* MoneyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoneyView.swift; sourceTree = "<group>"; };
+		828B378B2603BC110043B93A /* BoughtView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoughtView.swift; sourceTree = "<group>"; };
 		828EB06225EFD1BD00EC132C /* VendingMachineAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = VendingMachineAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		828EB06425EFD1BD00EC132C /* VendingMachineAppTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VendingMachineAppTests.swift; sourceTree = "<group>"; };
 		828EB06625EFD1BD00EC132C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -176,6 +182,9 @@
 				82F1617E25EE286D00E1C9F6 /* BeverageFactory.swift */,
 				829567FE25EF1A8000528A59 /* BeverageCreater.swift */,
 				82605F9B25FF9EBE00C3E84A /* SaveManager.swift */,
+				82820815260306D200615ED1 /* StockView.swift */,
+				828B37852603A9BE0043B93A /* MoneyView.swift */,
+				828B378B2603BC110043B93A /* BoughtView.swift */,
 			);
 			path = VendingMachineApp;
 			sourceTree = "<group>";
@@ -311,6 +320,7 @@
 			files = (
 				828EB08F25EFD52A00EC132C /* BeverageFactory.swift in Sources */,
 				82B22CF225E99A0700972CD7 /* Energydrink.swift in Sources */,
+				82820816260306D200615ED1 /* StockView.swift in Sources */,
 				82605F9C25FF9EBE00C3E84A /* SaveManager.swift in Sources */,
 				829C787F25E7C8B1007C4A68 /* VendingMachine.swift in Sources */,
 				8272F9D425F04194008167CE /* CaffeLatte.swift in Sources */,
@@ -327,11 +337,13 @@
 				8272F9B025F04101008167CE /* BananaMilk.swift in Sources */,
 				8272F9B825F04125008167CE /* Coke.swift in Sources */,
 				829C787025E7C2CB007C4A68 /* Beverage.swift in Sources */,
+				828B378C2603BC110043B93A /* BoughtView.swift in Sources */,
 				8272F9B425F04113008167CE /* Cider.swift in Sources */,
 				8272F9CE25F0418B008167CE /* CaffeMocha.swift in Sources */,
 				8272F9CA25F0414B008167CE /* Hot6.swift in Sources */,
 				82A851E525E63339001024D9 /* SceneDelegate.swift in Sources */,
 				829567FF25EF1A8000528A59 /* BeverageCreater.swift in Sources */,
+				828B37862603A9BE0043B93A /* MoneyView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/VendingMachineApp/VendingMachineApp/AppDelegate.swift
+++ b/VendingMachineApp/VendingMachineApp/AppDelegate.swift
@@ -35,6 +35,5 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     func applicationWillResignActive(_ application: UIApplication) {
-        SaveManager().savevendingMachineData(vendingMachine: vendingMachine)
     }
 }

--- a/VendingMachineApp/VendingMachineApp/BananaMilk.swift
+++ b/VendingMachineApp/VendingMachineApp/BananaMilk.swift
@@ -20,7 +20,7 @@ class BananaMilk : Milk{
     }
     
     required init?(coder: NSCoder) {
-        self.sugarContent = coder.decodeObject(forKey: "sugarContent") as? Int ?? 0
+        self.sugarContent = coder.decodeInteger(forKey: "sugarContent")
         super.init(coder: coder)
     }
     

--- a/VendingMachineApp/VendingMachineApp/Base.lproj/Main.storyboard
+++ b/VendingMachineApp/VendingMachineApp/Base.lproj/Main.storyboard
@@ -15,14 +15,6 @@
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="1024" height="1366"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceHorizontal="YES" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vie-Ai-3dx">
-                                <rect key="frame" x="47" y="1026" width="626" height="262"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <viewLayoutGuide key="contentLayoutGuide" id="4RZ-ho-M4I"/>
-                                <viewLayoutGuide key="frameLayoutGuide" id="gfv-EN-W3P"/>
-                            </scrollView>
-                        </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>

--- a/VendingMachineApp/VendingMachineApp/Base.lproj/Main.storyboard
+++ b/VendingMachineApp/VendingMachineApp/Base.lproj/Main.storyboard
@@ -15,13 +15,21 @@
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="1024" height="1366"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceHorizontal="YES" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vie-Ai-3dx">
+                                <rect key="frame" x="47" y="1026" width="626" height="262"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <viewLayoutGuide key="contentLayoutGuide" id="4RZ-ho-M4I"/>
+                                <viewLayoutGuide key="frameLayoutGuide" id="gfv-EN-W3P"/>
+                            </scrollView>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="141" y="139"/>
+            <point key="canvasLocation" x="140.625" y="138.79941434846265"/>
         </scene>
     </scenes>
     <resources>

--- a/VendingMachineApp/VendingMachineApp/Beverage.swift
+++ b/VendingMachineApp/VendingMachineApp/Beverage.swift
@@ -105,6 +105,15 @@ class Beverage : NSObject, NSCoding {
             productTypeList[ObjectIdentifier(self)]! += 1
         }
     }
+    
+    func removeProductType(productTypeList : inout [ObjectIdentifier : Int]){
+        if productTypeList[ObjectIdentifier(self)] == nil{
+            return
+        }
+        else{
+            productTypeList[ObjectIdentifier(self)]! -= 1
+        }
+    }
 }
 
 extension Beverage{

--- a/VendingMachineApp/VendingMachineApp/Beverage.swift
+++ b/VendingMachineApp/VendingMachineApp/Beverage.swift
@@ -56,14 +56,14 @@ class Beverage : NSObject, NSCoding {
     
     required init?(coder: NSCoder) {
         self.brand = coder.decodeObject(forKey: "brand") as? String ?? ""
-        self.volume = coder.decodeObject(forKey: "volume") as? Int ?? 0
-        self.price = coder.decodeObject(forKey: "price") as? Int ?? 0
+        self.volume = coder.decodeInteger(forKey: "volume")
+        self.price = coder.decodeInteger(forKey: "price")
         self.name = coder.decodeObject(forKey: "name") as? String ?? ""
         self.manufactured = coder.decodeObject(forKey: "manufactured") as? Date ?? Date()
-        self.temperature = coder.decodeObject(forKey: "temperature") as? Int ?? 0
-        self.kcal = coder.decodeObject(forKey: "kcal") as? Int ?? 0
-        self.HOTTEMSTANDARD = coder.decodeObject(forKey: "HOTTEMSTANDARD") as? Int ?? 0
-        self.HIGHCALSTANDARD = coder.decodeObject(forKey: "HIGHCALSTANDARD") as? Int ?? 0
+        self.temperature = coder.decodeInteger(forKey: "temperature")
+        self.kcal = coder.decodeInteger(forKey: "kcal")
+        self.HOTTEMSTANDARD = coder.decodeInteger(forKey: "HOTTEMSTANDARD")
+        self.HIGHCALSTANDARD = coder.decodeInteger(forKey: "HIGHCALSTANDARD")
     }
     
     

--- a/VendingMachineApp/VendingMachineApp/Beverage.swift
+++ b/VendingMachineApp/VendingMachineApp/Beverage.swift
@@ -105,15 +105,6 @@ class Beverage : NSObject, NSCoding {
             productTypeList[ObjectIdentifier(self)]! += 1
         }
     }
-    
-    func removeProductType(productTypeList : inout [ObjectIdentifier : Int]){
-        if productTypeList[ObjectIdentifier(self)] == nil{
-            return
-        }
-        else{
-            productTypeList[ObjectIdentifier(self)]! -= 1
-        }
-    }
 }
 
 extension Beverage{

--- a/VendingMachineApp/VendingMachineApp/Beverages.swift
+++ b/VendingMachineApp/VendingMachineApp/Beverages.swift
@@ -27,6 +27,7 @@ class Beverages : NSObject , NSCoding{
     
     func addBeverage(beverage : Beverage) -> Void{
         beverages.append(beverage)
+        NotificationCenter.default.post(name: NSNotification.Name("addSomething"), object: nil)
     }
     
     func showValidatecurrentBeverageList() -> [Beverage]{

--- a/VendingMachineApp/VendingMachineApp/Beverages.swift
+++ b/VendingMachineApp/VendingMachineApp/Beverages.swift
@@ -27,7 +27,7 @@ class Beverages : NSObject , NSCoding{
     
     func addBeverage(beverage : Beverage) -> Void{
         beverages.append(beverage)
-        NotificationCenter.default.post(name: NSNotification.Name("addSomething"), object: nil)
+        NotificationCenter.default.post(name: NSNotification.Name("redrawImageandLabel"), object: nil)
     }
     
     func showValidatecurrentBeverageList() -> [Beverage]{
@@ -41,9 +41,8 @@ class Beverages : NSObject , NSCoding{
     }
     
     func takeBeverage(beverage : Beverage){
-        if let removeTarget = beverages.firstIndex(of: beverage){
-            self.beverages.remove(at: removeTarget)
-        }
+        var tempbeverageList : [ObjectIdentifier : Int] = makeCurrentBeverageObjectIdentifierList()
+        beverage.removeProductType(productTypeList: &tempbeverageList)
     }
     
     func showLowerpriceThan(money : Money) -> [Beverage]{

--- a/VendingMachineApp/VendingMachineApp/Beverages.swift
+++ b/VendingMachineApp/VendingMachineApp/Beverages.swift
@@ -40,9 +40,23 @@ class Beverages : NSObject , NSCoding{
         return beverageList
     }
     
+    private func beverageType(beverage : Beverage) -> Int {
+        var tempbeverageTypeindex : Int = 0
+        for i in 0..<beverageTypeList.count{
+            if beverageTypeList[i] == type(of: beverage){
+                tempbeverageTypeindex = i
+            }
+        }
+        return tempbeverageTypeindex
+    }
+    
     func takeBeverage(beverage : Beverage){
-        var tempbeverageList : [ObjectIdentifier : Int] = makeCurrentBeverageObjectIdentifierList()
-        beverage.removeProductType(productTypeList: &tempbeverageList)
+        if let firstindex = beverages.firstIndex(of: beverage){
+            beverages.remove(at: firstindex)
+            let userInfo : [String : Int] = ["ImageIndex" : beverageType(beverage: beverage)]
+            NotificationCenter.default.post(name: NSNotification.Name("purchaseBeverage"), object: nil, userInfo: userInfo)
+        }
+        NotificationCenter.default.post(name: NSNotification.Name("redrawImageandLabel"), object: nil)
     }
     
     func showLowerpriceThan(money : Money) -> [Beverage]{
@@ -90,9 +104,9 @@ class Beverages : NSObject , NSCoding{
     }
     
     func sendCurrentBeverageObjectIdentifierCount(beverage : Beverage) -> Int{
-        let tempbeverageList : [ObjectIdentifier : Int] = makeCurrentBeverageObjectIdentifierList()
+        let tempList = makeCurrentBeverageObjectIdentifierList()
         var tempResult = 0
-        if let tempbeverageCount = tempbeverageList[ObjectIdentifier(beverage)]{
+        if let tempbeverageCount = tempList[ObjectIdentifier(beverage)]{
             tempResult = tempbeverageCount
         }
         return tempResult

--- a/VendingMachineApp/VendingMachineApp/BoughtView.swift
+++ b/VendingMachineApp/VendingMachineApp/BoughtView.swift
@@ -1,0 +1,14 @@
+//
+//  BoughtView.swift
+//  VendingMachineApp
+//
+//  Created by 박정하 on 2021/03/19.
+//
+
+import UIKit
+
+class boughtView: UIScrollView {
+    private var ImageView : UIImageView!
+    
+    
+}

--- a/VendingMachineApp/VendingMachineApp/BoughtView.swift
+++ b/VendingMachineApp/VendingMachineApp/BoughtView.swift
@@ -8,7 +8,43 @@
 import UIKit
 
 class boughtView: UIScrollView {
-    private var ImageView : UIImageView!
+    private var vendingMachine : VendingMachine!
+    private let appDelegate : AppDelegate
+    private var boughtImages : [UIImageView]
     
+    override init(frame : CGRect) {
+        self.appDelegate = UIApplication.shared.delegate as! AppDelegate
+        self.vendingMachine = appDelegate.vendingMachine
+        boughtImages = []
+        super.init(frame: frame)
+        self.backgroundColor = .systemGray2
+    }
     
+    required init?(coder: NSCoder) {
+        self.appDelegate = UIApplication.shared.delegate as! AppDelegate
+        
+        boughtImages = []
+        super.init(coder: coder)
+    }
+    
+    func makeBoughtImageView(ImageTitle : StockView.stockTitle){
+        let tempImageView : UIImageView = UIImageView(image: UIImage(named: ImageTitle.rawValue))
+        tempImageView.backgroundColor = .white
+        self.addSubview(tempImageView)
+        tempImageView.translatesAutoresizingMaskIntoConstraints = false
+        tempImageView.widthAnchor.constraint(equalToConstant: 140).isActive = true
+        tempImageView.heightAnchor.constraint(equalToConstant: 100).isActive = true
+        tempImageView.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
+        
+        if boughtImages.count == 0 {
+            tempImageView.leftAnchor.constraint(equalTo: self.leftAnchor, constant: 0).isActive = true
+        }
+        else{
+            tempImageView.leftAnchor.constraint(equalTo: boughtImages[boughtImages.count-1].leftAnchor, constant: 70).isActive = true
+        }
+        tempImageView.contentMode = .scaleAspectFit
+        tempImageView.layer.cornerRadius = 10
+        self.contentSize = CGSize(width: self.contentSize.width + CGFloat(70), height: self.contentSize.height)
+        self.boughtImages.append(tempImageView)
+    }
 }

--- a/VendingMachineApp/VendingMachineApp/CaffeLatte.swift
+++ b/VendingMachineApp/VendingMachineApp/CaffeLatte.swift
@@ -20,12 +20,13 @@ class CaffeeLatte : Coffee{
     }
     
     required init?(coder: NSCoder) {
-        self.sugarContent = coder.decodeObject(forKey: "sugarContent") as? Int ?? 0
+        self.sugarContent = coder.decodeInteger(forKey: "sugarContent")
         super.init(coder: coder)
     }
     
     override func encode(with coder: NSCoder) {
         coder.encode(sugarContent, forKey: "sugarContent")
+        super.encode(with: coder)
     }
     
     func isSugarfree(standard : Int) -> Bool {

--- a/VendingMachineApp/VendingMachineApp/CaffeMocha.swift
+++ b/VendingMachineApp/VendingMachineApp/CaffeMocha.swift
@@ -20,7 +20,7 @@ class CaffeMocha : Coffee{
     }
     
     required init?(coder: NSCoder) {
-        self.cream = coder.decodeObject(forKey: "cream") as? Bool ?? false
+        self.cream = coder.decodeBool(forKey: "cream")
         super.init(coder: coder)
     }
     

--- a/VendingMachineApp/VendingMachineApp/Cider.swift
+++ b/VendingMachineApp/VendingMachineApp/Cider.swift
@@ -20,7 +20,7 @@ class Cider : Soda{
     }
     
     required init?(coder: NSCoder) {
-        self.appleContent = coder.decodeObject(forKey: "appleContent") as? Int ?? 0
+        self.appleContent = coder.decodeInteger(forKey: "appleContent")
         super.init(coder: coder)
     }
     

--- a/VendingMachineApp/VendingMachineApp/Coffee.swift
+++ b/VendingMachineApp/VendingMachineApp/Coffee.swift
@@ -30,7 +30,7 @@ class Coffee : Beverage {
     }
     
     required init?(coder: NSCoder) {
-        self.caffeineContent = coder.decodeObject(forKey: "caffeineContent") as? Int ?? 0
+        self.caffeineContent = coder.decodeInteger(forKey: "caffeineContent")
         super.init(coder: coder)
     }
     

--- a/VendingMachineApp/VendingMachineApp/Coke.swift
+++ b/VendingMachineApp/VendingMachineApp/Coke.swift
@@ -24,13 +24,11 @@ class Coke : Soda{
     }
     
     required init?(coder: NSCoder) {
-        //self.product = coder.decodeObject(forKey: "product") as? Product ?? .light
         self.product = .light
         super.init(coder: coder)
     }
     
     override func encode(with coder: NSCoder) {
-        //coder.encode(self.product, forKey: "product")
         super.encode(with: coder)
     }
     

--- a/VendingMachineApp/VendingMachineApp/Energydrink.swift
+++ b/VendingMachineApp/VendingMachineApp/Energydrink.swift
@@ -25,7 +25,7 @@ class Energydrink : Beverage {
     }
     
     required init?(coder: NSCoder) {
-        self.caffeineContent = coder.decodeObject(forKey: "caffeineContent") as? Int ?? 0
+        self.caffeineContent = coder.decodeInteger(forKey: "caffeineContent")
         super.init(coder: coder)
     }
 

--- a/VendingMachineApp/VendingMachineApp/Hot6.swift
+++ b/VendingMachineApp/VendingMachineApp/Hot6.swift
@@ -20,7 +20,7 @@ class Hot6 : Energydrink {
     }
     
     required init?(coder: NSCoder) {
-        self.taurineContent = coder.decodeObject(forKey: "taurineContent") as? Int ?? 0
+        self.taurineContent = coder.decodeInteger(forKey: "taurineContent")
         super.init(coder: coder)
     }
     

--- a/VendingMachineApp/VendingMachineApp/Milk.swift
+++ b/VendingMachineApp/VendingMachineApp/Milk.swift
@@ -29,7 +29,7 @@ class Milk : Beverage {
     }
     
     required init?(coder: NSCoder) {
-        self.fatContent = coder.decodeObject(forKey: "fatContent") as? Int ?? 0
+        self.fatContent = coder.decodeInteger(forKey: "fatContent")
         super.init(coder: coder)
     }
     

--- a/VendingMachineApp/VendingMachineApp/Money.swift
+++ b/VendingMachineApp/VendingMachineApp/Money.swift
@@ -40,7 +40,7 @@ class Money : NSObject, NSCoding{
     
     func addMoney(money : Money) -> Void{
         self.Money += money.Money
-        NotificationCenter.default.post(name: NSNotification.Name("addSomething"), object: nil)
+        NotificationCenter.default.post(name: NSNotification.Name("redrawImageandLabel"), object: nil)
     }
     
     func canBuybeverage(price : Int) -> Bool{

--- a/VendingMachineApp/VendingMachineApp/Money.swift
+++ b/VendingMachineApp/VendingMachineApp/Money.swift
@@ -11,8 +11,8 @@ class Money : NSObject, NSCoding{
     
     private var Money : Int
     
-    init(money : Int) {
-        self.Money = money
+    init(money : Money.moneyUnit) {
+        self.Money = money.rawValue
     }
     
     func encode(with coder: NSCoder) {
@@ -40,6 +40,7 @@ class Money : NSObject, NSCoding{
     
     func addMoney(money : Money) -> Void{
         self.Money += money.Money
+        NotificationCenter.default.post(name: NSNotification.Name("addSomething"), object: nil)
     }
     
     func canBuybeverage(price : Int) -> Bool{
@@ -50,3 +51,4 @@ class Money : NSObject, NSCoding{
         return "\(self.Money)원"
     }
 }
+

--- a/VendingMachineApp/VendingMachineApp/MoneyView.swift
+++ b/VendingMachineApp/VendingMachineApp/MoneyView.swift
@@ -8,24 +8,29 @@
 import UIKit
 
 class MoneyView : UIView{
-    private var MoneyaddButtons : [UIButton]!
-    private var currentMoneyLabel : UILabel!
+    private var vendingMachine : VendingMachine!
+    private let appDelegate : AppDelegate
+    private var MoneyaddButtons : [UIButton]
+    private var currentMoneyLabel : UILabel
     
     override init(frame: CGRect) {
+        self.appDelegate = UIApplication.shared.delegate as! AppDelegate
+        self.vendingMachine = appDelegate.vendingMachine
+        MoneyaddButtons = []
+        currentMoneyLabel = UILabel()
         super.init(frame: frame)
-    }
-    
-    init(frame: CGRect, moneyMethod : Selector) {
-        super.init(frame: frame)
-        initMoneyaddButtons(method: moneyMethod)
+        initMoneyaddButtons()
         initCurrentMoneyLabel()
     }
     
     required init?(coder: NSCoder) {
+        self.appDelegate = UIApplication.shared.delegate as! AppDelegate
+        MoneyaddButtons = []
+        currentMoneyLabel = UILabel()
         super.init(coder: coder)
     }
     
-    func initMoneyaddButtons(method : Selector){
+    func initMoneyaddButtons(){
         for i in 0..<2 {
             MoneyaddButtons.append(UIButton())
             MoneyaddButtons[i].translatesAutoresizingMaskIntoConstraints = false
@@ -35,10 +40,10 @@ class MoneyView : UIView{
             MoneyaddButtons[i].heightAnchor.constraint(equalToConstant: 50).isActive = true
             MoneyaddButtons[i].centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
             MoneyaddButtons[i].tag = i
-            MoneyaddButtons[i].addTarget(self, action: method, for: .touchUpInside)
+            MoneyaddButtons[i].addTarget(self, action: #selector(addMoney(sender:)), for: .touchUpInside)
         }
-        MoneyaddButtons[0].leftAnchor.constraint(equalTo: self.leftAnchor, constant: 35).isActive = true
-        MoneyaddButtons[1].leftAnchor.constraint(equalTo: MoneyaddButtons[0].rightAnchor, constant: 25).isActive = true
+        MoneyaddButtons[0].leftAnchor.constraint(equalTo: self.leftAnchor, constant: 5).isActive = true
+        MoneyaddButtons[1].rightAnchor.constraint(equalTo: self.rightAnchor, constant: -5).isActive = true
         MoneyaddButtons[0].setTitle("+1000원", for: .normal)
         MoneyaddButtons[1].setTitle("+5000원", for: .normal)
     }
@@ -50,9 +55,17 @@ class MoneyView : UIView{
         self.addSubview(currentMoneyLabel)
         currentMoneyLabel.widthAnchor.constraint(equalToConstant: 75).isActive = true
         currentMoneyLabel.heightAnchor.constraint(equalToConstant: 50).isActive = true
-        currentMoneyLabel.leftAnchor.constraint(equalTo: MoneyaddButtons[0].centerXAnchor).isActive = true
-        currentMoneyLabel.centerYAnchor.constraint(equalTo: MoneyaddButtons[0].bottomAnchor, constant: 30).isActive = true
+        currentMoneyLabel.centerXAnchor.constraint(equalTo: self.centerXAnchor).isActive = true
+        currentMoneyLabel.centerYAnchor.constraint(equalTo: self.centerYAnchor, constant: 40).isActive = true
+    }
+
+    func updateMoeny(money: String){
+        currentMoneyLabel.text = money
     }
     
-
+    @objc private func addMoney(sender: UIButton){
+        if let tempMoney = Money.moneyUnit.init(index: sender.tag) {
+            vendingMachine.addMoney(money: Money.init(money: tempMoney))
+        }
+    }
 }

--- a/VendingMachineApp/VendingMachineApp/MoneyView.swift
+++ b/VendingMachineApp/VendingMachineApp/MoneyView.swift
@@ -1,0 +1,58 @@
+//
+//  moneyView.swift
+//  VendingMachineApp
+//
+//  Created by 박정하 on 2021/03/19.
+//
+
+import UIKit
+
+class MoneyView : UIView{
+    private var MoneyaddButtons : [UIButton]!
+    private var currentMoneyLabel : UILabel!
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    init(frame: CGRect, moneyMethod : Selector) {
+        super.init(frame: frame)
+        initMoneyaddButtons(method: moneyMethod)
+        initCurrentMoneyLabel()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    func initMoneyaddButtons(method : Selector){
+        for i in 0..<2 {
+            MoneyaddButtons.append(UIButton())
+            MoneyaddButtons[i].translatesAutoresizingMaskIntoConstraints = false
+            self.addSubview(MoneyaddButtons[i])
+            MoneyaddButtons[i].setTitleColor(.systemBlue, for: .normal)
+            MoneyaddButtons[i].widthAnchor.constraint(equalToConstant: 75).isActive = true
+            MoneyaddButtons[i].heightAnchor.constraint(equalToConstant: 50).isActive = true
+            MoneyaddButtons[i].centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
+            MoneyaddButtons[i].tag = i
+            MoneyaddButtons[i].addTarget(self, action: method, for: .touchUpInside)
+        }
+        MoneyaddButtons[0].leftAnchor.constraint(equalTo: self.leftAnchor, constant: 35).isActive = true
+        MoneyaddButtons[1].leftAnchor.constraint(equalTo: MoneyaddButtons[0].rightAnchor, constant: 25).isActive = true
+        MoneyaddButtons[0].setTitle("+1000원", for: .normal)
+        MoneyaddButtons[1].setTitle("+5000원", for: .normal)
+    }
+    
+    func initCurrentMoneyLabel() -> Void {
+        currentMoneyLabel.text = "0원"
+        currentMoneyLabel.textAlignment = .center
+        currentMoneyLabel.translatesAutoresizingMaskIntoConstraints = false
+        self.addSubview(currentMoneyLabel)
+        currentMoneyLabel.widthAnchor.constraint(equalToConstant: 75).isActive = true
+        currentMoneyLabel.heightAnchor.constraint(equalToConstant: 50).isActive = true
+        currentMoneyLabel.leftAnchor.constraint(equalTo: MoneyaddButtons[0].centerXAnchor).isActive = true
+        currentMoneyLabel.centerYAnchor.constraint(equalTo: MoneyaddButtons[0].bottomAnchor, constant: 30).isActive = true
+    }
+    
+
+}

--- a/VendingMachineApp/VendingMachineApp/Monster.swift
+++ b/VendingMachineApp/VendingMachineApp/Monster.swift
@@ -20,7 +20,7 @@ class Monster : Energydrink {
     }
     
     required init?(coder: NSCoder) {
-        self.glutamineContent = coder.decodeObject(forKey: "glutamineContent") as? Int ?? 0
+        self.glutamineContent = coder.decodeInteger(forKey: "glutamineContent")
         super.init(coder: coder)
     }
     

--- a/VendingMachineApp/VendingMachineApp/SaveManager.swift
+++ b/VendingMachineApp/VendingMachineApp/SaveManager.swift
@@ -9,9 +9,14 @@ import Foundation
 
 class SaveManager {
     func savevendingMachineData(vendingMachine : VendingMachine){
-        if let savedData = try? NSKeyedArchiver.archivedData(withRootObject: vendingMachine, requiringSecureCoding: false){
-            UserDefaults.standard.set(savedData, forKey: "vendingMachine")
+        var savaData : Data!
+        do{
+            savaData = try NSKeyedArchiver.archivedData(withRootObject: vendingMachine, requiringSecureCoding: false)
+        }catch{
+            print(error.localizedDescription)
+            return
         }
+        UserDefaults.standard.set(savaData, forKey: "vendingMachine")
     }
     
     func loadvendingMachineData() -> VendingMachine?{

--- a/VendingMachineApp/VendingMachineApp/SceneDelegate.swift
+++ b/VendingMachineApp/VendingMachineApp/SceneDelegate.swift
@@ -26,7 +26,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func sceneDidBecomeActive(_ scene: UIScene) {
-        
     }
 
     func sceneWillResignActive(_ scene: UIScene) {

--- a/VendingMachineApp/VendingMachineApp/Soda.swift
+++ b/VendingMachineApp/VendingMachineApp/Soda.swift
@@ -21,7 +21,7 @@ class Soda : Beverage {
     }
     
     required init?(coder: NSCoder) {
-        self.sugarContent = coder.decodeObject(forKey: "sugarContent") as? Int ?? 0
+        self.sugarContent = coder.decodeInteger(forKey: "sugarContent")
         super.init(coder: coder)
     }
     

--- a/VendingMachineApp/VendingMachineApp/StockView.swift
+++ b/VendingMachineApp/VendingMachineApp/StockView.swift
@@ -76,7 +76,6 @@ class StockView : UIView {
         self.purchaseButton.heightAnchor.constraint(equalToConstant: 25).isActive = true
         self.purchaseButton.centerXAnchor.constraint(equalTo: self.centerXAnchor).isActive = true
         self.purchaseButton.topAnchor.constraint(equalTo: self.stockLabel.bottomAnchor, constant: 10).isActive = true
-        //self.purchaseButton.addTarget(self, action: purchaseStockMethod, for: .touchUpInside)
     }
     
     
@@ -103,7 +102,7 @@ class StockView : UIView {
         self.purchaseButton.tag = tag
     }
     
-    @objc func addBeverage(sender : UIButton){
+    @objc private func addBeverage(sender : UIButton){
         let tempBeverage = vendingMachine.sendBeverageInFactory(index: sender.tag)
         vendingMachine.addBeverage(beverage: tempBeverage)
     }

--- a/VendingMachineApp/VendingMachineApp/StockView.swift
+++ b/VendingMachineApp/VendingMachineApp/StockView.swift
@@ -1,0 +1,110 @@
+//
+//  stock.swift
+//  VendingMachineApp
+//
+//  Created by 박정하 on 2021/03/18.
+//
+
+import UIKit
+
+class StockView : UIView {
+    private var vendingMachine : VendingMachine!
+    private let appDelegate : AppDelegate
+    private var addButton : UIButton!
+    private var beverageImage : UIImageView!
+    private var stockLabel : UILabel!
+    private var purchaseButton : UIButton!
+    
+    enum stockTitle : String, CaseIterable {
+        case bananaMilk = "BananaMilk", strawberryMilk = "StrawberryMilk", somersby = "somersby", coke = "coke", HOT6 = "HOT6", Monster = "Monster", CaffeMocha = "CaffeMocha", CafeLatte = "CafeLatte"
+    }
+    
+    override init(frame : CGRect) {
+        self.appDelegate = UIApplication.shared.delegate as! AppDelegate
+        super.init(frame: frame)
+    }
+    
+    init(frame : CGRect, ImageName : stockTitle) {
+        self.appDelegate = UIApplication.shared.delegate as! AppDelegate
+        self.vendingMachine = appDelegate.vendingMachine
+        self.addButton = UIButton()
+        self.beverageImage = UIImageView(image: UIImage(named: ImageName.rawValue))
+        self.purchaseButton = UIButton()
+        self.stockLabel = UILabel()
+        super.init(frame: frame)
+        setupAddButton()
+        setupImage()
+        setupstockLabel()
+        setupPurchaseButton()
+    }
+    
+    required init?(coder: NSCoder) {
+        self.appDelegate = UIApplication.shared.delegate as! AppDelegate
+        super.init(coder: coder)
+    }
+    
+    private func setupImage(){
+        self.beverageImage.backgroundColor = .white
+        self.addSubview(self.beverageImage)
+        self.beverageImage.translatesAutoresizingMaskIntoConstraints = false
+        self.beverageImage.widthAnchor.constraint(equalToConstant: 140).isActive = true
+        self.beverageImage.heightAnchor.constraint(equalToConstant: 100).isActive = true
+        self.beverageImage.centerXAnchor.constraint(equalTo: self.centerXAnchor).isActive = true
+        self.beverageImage.topAnchor.constraint(equalTo: self.addButton.bottomAnchor, constant: 5).isActive = true
+        self.beverageImage.contentMode = .scaleAspectFit
+        self.beverageImage.layer.cornerRadius = 10
+    }
+    
+    private func setupAddButton(){
+        self.addButton.setTitle("추가", for: .normal)
+        self.addButton.setTitleColor(.systemBlue, for: .normal)
+        self.addSubview(self.addButton)
+        self.addButton.translatesAutoresizingMaskIntoConstraints = false
+        self.addButton.widthAnchor.constraint(equalToConstant: 50).isActive = true
+        self.addButton.heightAnchor.constraint(equalToConstant: 25).isActive = true
+        self.addButton.centerXAnchor.constraint(equalTo: self.centerXAnchor).isActive = true
+        self.addButton.topAnchor.constraint(equalTo: self.topAnchor, constant: 10).isActive = true
+        self.addButton.addTarget(self, action: #selector(addBeverage(sender:)), for: .touchUpInside)
+    }
+    
+    private func setupPurchaseButton(){
+        self.purchaseButton.setTitle("구매", for: .normal)
+        self.purchaseButton.setTitleColor(.systemBlue, for: .normal)
+        self.addSubview(self.purchaseButton)
+        self.purchaseButton.translatesAutoresizingMaskIntoConstraints = false
+        self.purchaseButton.widthAnchor.constraint(equalToConstant: 50).isActive = true
+        self.purchaseButton.heightAnchor.constraint(equalToConstant: 25).isActive = true
+        self.purchaseButton.centerXAnchor.constraint(equalTo: self.centerXAnchor).isActive = true
+        self.purchaseButton.topAnchor.constraint(equalTo: self.stockLabel.bottomAnchor, constant: 10).isActive = true
+        //self.purchaseButton.addTarget(self, action: purchaseStockMethod, for: .touchUpInside)
+    }
+    
+    
+    private func setupstockLabel(){
+        self.stockLabel.text = "0개"
+        self.stockLabel.textAlignment = .center
+        self.addSubview(self.stockLabel)
+        self.stockLabel.translatesAutoresizingMaskIntoConstraints = false
+        self.stockLabel.widthAnchor.constraint(equalToConstant: 50).isActive = true
+        self.stockLabel.heightAnchor.constraint(equalToConstant: 25).isActive = true
+        self.stockLabel.centerXAnchor.constraint(equalTo: self.beverageImage.centerXAnchor).isActive = true
+        self.stockLabel.topAnchor.constraint(equalTo: self.beverageImage.bottomAnchor, constant: 5).isActive = true
+    }
+    
+    func updateStocklabel(stockCount : Int){
+        self.stockLabel.text = "\(stockCount)개"
+    }
+    
+    func setaddButtontag(tag : Int){
+        self.addButton.tag = tag
+    }
+
+    func setpurchaseButtontag(tag : Int){
+        self.purchaseButton.tag = tag
+    }
+    
+    @objc func addBeverage(sender : UIButton){
+        let tempBeverage = vendingMachine.sendBeverageInFactory(index: sender.tag)
+        vendingMachine.addBeverage(beverage: tempBeverage)
+    }
+}

--- a/VendingMachineApp/VendingMachineApp/StockView.swift
+++ b/VendingMachineApp/VendingMachineApp/StockView.swift
@@ -76,6 +76,7 @@ class StockView : UIView {
         self.purchaseButton.heightAnchor.constraint(equalToConstant: 25).isActive = true
         self.purchaseButton.centerXAnchor.constraint(equalTo: self.centerXAnchor).isActive = true
         self.purchaseButton.topAnchor.constraint(equalTo: self.stockLabel.bottomAnchor, constant: 10).isActive = true
+        self.purchaseButton.addTarget(self, action: #selector(buyBeverage(sender:)), for: .touchUpInside)
     }
     
     
@@ -105,5 +106,10 @@ class StockView : UIView {
     @objc private func addBeverage(sender : UIButton){
         let tempBeverage = vendingMachine.sendBeverageInFactory(index: sender.tag)
         vendingMachine.addBeverage(beverage: tempBeverage)
+    }
+    
+    @objc private func buyBeverage(sender: UIButton){
+        let tempBeverage = vendingMachine.sendBeverageInFactory(index: sender.tag)
+        vendingMachine.buyBeverage(beverage: tempBeverage)
     }
 }

--- a/VendingMachineApp/VendingMachineApp/StrawBerryMilk.swift
+++ b/VendingMachineApp/VendingMachineApp/StrawBerryMilk.swift
@@ -20,7 +20,7 @@ class StrawBerryMilk : Milk{
     }
     
     required init?(coder: NSCoder) {
-        self.StrawBerryContent = coder.decodeObject(forKey: "StrawBerryContent") as? Int ?? 0
+        self.StrawBerryContent = coder.decodeInteger(forKey: "StrawBerryContent")
         super.init(coder: coder)
     }
     

--- a/VendingMachineApp/VendingMachineApp/VendingMachine.swift
+++ b/VendingMachineApp/VendingMachineApp/VendingMachine.swift
@@ -14,7 +14,7 @@ class VendingMachine : NSObject, NSCoding{
     private var BeverageFactory : [Beverage]
     
     override init() {
-        self.money = Money.init(money: 0)
+        self.money = Money.init(money: .OneThousand)
         self.currentBeverages = Beverages()
         self.bought = Beverages()
         BeverageFactory = currentBeverages.makeBeverageofFactroy()
@@ -28,7 +28,7 @@ class VendingMachine : NSObject, NSCoding{
     }
     
     required init?(coder: NSCoder) {
-        self.money = coder.decodeObject(forKey: "Money") as? Money ?? Money.init(money: 0)
+        self.money = coder.decodeObject(forKey: "Money") as? Money ?? Money.init(money: .OneThousand)
         self.currentBeverages = coder.decodeObject(forKey: "currentBeverages") as? Beverages ?? Beverages()
         self.bought = coder.decodeObject(forKey: "boughtList") as? Beverages ?? Beverages()
         self.BeverageFactory = coder.decodeObject(forKey: "BeverageFactory") as? [Beverage] ?? []

--- a/VendingMachineApp/VendingMachineApp/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/ViewController.swift
@@ -11,6 +11,7 @@ import UIKit
     private var vendingMachine : VendingMachine!
     private let appDelegate : AppDelegate
     private var stockViews : [StockView]
+    private var moneyview : MoneyView!
     
     init() {
         self.appDelegate = UIApplication.shared.delegate as! AppDelegate
@@ -43,19 +44,22 @@ import UIKit
     
     func drawStockViews(){
         for i in 0..<StockView.stockTitle.allCases.count{
-            let viewCGRECT : CGRect!
+            let stockviewCGRect : CGRect!
             if i < 4 {
-                viewCGRECT = CGRect(x: i * 170, y: 40, width: 140, height: 200)
+                stockviewCGRect = CGRect(x: i * 170, y: 40, width: 140, height: 200)
             }
             else {
-                viewCGRECT = CGRect(x: (i - 4) * 170, y: 280, width: 140, height: 200)
+                stockviewCGRect = CGRect(x: (i - 4) * 170, y: 280, width: 140, height: 200)
             }
-            let stockview : StockView = StockView.init(frame: viewCGRECT, ImageName: StockView.stockTitle.allCases[i])
+            let stockview : StockView = StockView.init(frame: stockviewCGRect, ImageName: StockView.stockTitle.allCases[i])
             stockview.setaddButtontag(tag: i)
             stockview.setpurchaseButtontag(tag: i)
             stockViews.append(stockview)
             view.addSubview(stockview)
         }
+        let moneyViewCGRect : CGRect = CGRect(x: 750, y: 80, width: 200, height: 150)
+        moneyview = MoneyView.init(frame: moneyViewCGRect)
+        view.addSubview(moneyview)
     }
     
     
@@ -77,6 +81,6 @@ import UIKit
         for i in 0..<StockView.stockTitle.allCases.count{
             stockViews[i].updateStocklabel(stockCount: vendingMachine.drawStockLabel(beverage: vendingMachine.sendBeverageInFactory(index: i)))
         }
-        //currentMoneyLabel.text = vendingMachine.drawCurrentMoney()
+        moneyview.updateMoeny(money: vendingMachine.drawCurrentMoney())
     }
 }

--- a/VendingMachineApp/VendingMachineApp/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/ViewController.swift
@@ -40,6 +40,7 @@ class ViewController: UIViewController {
     }
     
     override func viewDidLoad() {
+        NotificationCenter.default.addObserver(self, selector: #selector(didReceiveTestNotification), name: NSNotification.Name("addSomething"), object: nil)
         self.vendingMachine = appDelegate.vendingMachine
         super.viewDidLoad()
     }
@@ -50,7 +51,7 @@ class ViewController: UIViewController {
         initvendingMachineBeverageLabels()
         initMoneyaddButtons()
         initCurrentMoneyLabel()
-        redrawMoneyandStockFromSaveData()
+        redrawMoneyandStock()
         super.viewWillAppear(false)
     }
     
@@ -61,6 +62,10 @@ class ViewController: UIViewController {
         BeverageButtons[index].translatesAutoresizingMaskIntoConstraints = false
         BeverageButtons[index].widthAnchor.constraint(equalToConstant: 100).isActive = true
         BeverageButtons[index].heightAnchor.constraint(equalToConstant: 50).isActive = true
+    }
+    
+    @objc func didReceiveTestNotification(){
+        redrawMoneyandStock()
     }
     
     func initBeverageButtons(){
@@ -151,7 +156,7 @@ class ViewController: UIViewController {
         currentMoneyLabel.centerYAnchor.constraint(equalTo: MoneyaddButtons[0].bottomAnchor, constant: 20).isActive = true
     }
     
-    func redrawMoneyandStockFromSaveData(){
+    func redrawMoneyandStock(){
         for i in 0..<stockLabel.count{
             stockLabel[i].text = "\(vendingMachine.drawStockLabel(beverage: vendingMachine.sendBeverageInFactory(index: i)))개"
         }
@@ -161,13 +166,11 @@ class ViewController: UIViewController {
     @objc func addBeverage(sender : UIButton) {
         let tempBeverage = vendingMachine.sendBeverageInFactory(index: sender.tag)
         vendingMachine.addBeverage(beverage: tempBeverage)
-        stockLabel[sender.tag].text = "\(vendingMachine.drawStockLabel(beverage: tempBeverage))개"
     }
     
     @objc func addMoney(sender: UIButton){
         if let tempMoney = Money.moneyUnit.init(index: sender.tag) {
-            vendingMachine.addMoney(money: Money.init(money: tempMoney.rawValue))
-            currentMoneyLabel.text = vendingMachine.drawCurrentMoney()
+            vendingMachine.addMoney(money: Money.init(money: tempMoney))
         }
     }
 }

--- a/VendingMachineApp/VendingMachineApp/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/ViewController.swift
@@ -7,55 +7,33 @@
 
 import UIKit
 
-class ViewController: UIViewController {
+@objc class ViewController: UIViewController {
     private var vendingMachine : VendingMachine!
     private let appDelegate : AppDelegate
-    private var childView : [UIView]
-    private var BeverageButtons : [UIButton]
-    private var MoneyaddButtons : [UIButton]
-    private var beverageImageViews : [UIImageView]
-    private var currentMoneyLabel : UILabel
-    private var stockLabel : [UILabel]
-    private var buyButton : [UIButton]
-    private var UIImagetitles : [String]
+    private var stockViews : [StockView]
     
     init() {
         self.appDelegate = UIApplication.shared.delegate as! AppDelegate
-        self.childView = []
-        self.BeverageButtons = []
-        self.MoneyaddButtons = []
-        self.beverageImageViews = []
-        self.currentMoneyLabel = UILabel()
-        self.stockLabel = []
-        self.buyButton = []
-        self.UIImagetitles = ["BananaMilk", "StrawberryMilk", "somersby", "coke", "HOT6", "Monster", "CaffeMocha", "CafeLatte"]
+        stockViews = []
         super.init(nibName: nil, bundle: nil)
     }
     
     required init?(coder: NSCoder) {
         self.appDelegate = UIApplication.shared.delegate as! AppDelegate
-        self.childView = []
-        self.BeverageButtons = []
-        self.MoneyaddButtons = []
-        self.beverageImageViews = []
-        self.currentMoneyLabel = UILabel()
-        self.stockLabel = []
-        self.buyButton = []
-        self.UIImagetitles = ["BananaMilk", "StrawberryMilk", "somersby", "coke", "HOT6", "Monster", "CaffeMocha", "CafeLatte"]
+        stockViews = []
         super.init(coder: coder)
     }
     
     override func viewDidLoad() {
-        NotificationCenter.default.addObserver(self, selector: #selector(receiveaddNotification), name: NSNotification.Name("addSomething"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(receiveaddNotification), name: NSNotification.Name("redrawImageandLabel"), object: nil)
         self.vendingMachine = appDelegate.vendingMachine
         super.viewDidLoad()
     }
     
     override func viewWillAppear(_ animated: Bool) {
-        drawstockViews()
-        initMoneyaddButtons()
-        initCurrentMoneyLabel()
-        redrawMoneyandStock()
+        view.backgroundColor = .systemGray3
+        drawStockViews()
+        NotificationCenter.default.post(name: NSNotification.Name("redrawImageandLabel"), object: nil)
         super.viewWillAppear(false)
     }
     
@@ -63,127 +41,42 @@ class ViewController: UIViewController {
         redrawMoneyandStock()
     }
     
-    func drawstockViews(){
-        view.backgroundColor = .systemGray3
-        for i in 0..<UIImagetitles.count{
-            childView.append(initChildView(imageName: UIImagetitles[i]))
-            view.addSubview(childView[i])
-            if i == 0 {
-                childView[i].centerXAnchor.constraint(equalTo: view.leftAnchor, constant: 100).isActive = true
-                childView[i].centerYAnchor.constraint(equalTo: view.topAnchor, constant: 150).isActive = true
-            }
-            else if i > 3 {
-                childView[i].centerXAnchor.constraint(equalTo: childView[0].centerXAnchor, constant: 200 * CGFloat(i-4)).isActive = true
-                childView[i].centerYAnchor.constraint(equalTo: childView[0].bottomAnchor, constant: 150).isActive = true
+    func drawStockViews(){
+        for i in 0..<StockView.stockTitle.allCases.count{
+            let viewCGRECT : CGRect!
+            if i < 4 {
+                viewCGRECT = CGRect(x: i * 170, y: 40, width: 140, height: 200)
             }
             else {
-                childView[i].centerXAnchor.constraint(equalTo: childView[0].centerXAnchor, constant: 200 * CGFloat(i)).isActive = true
-                childView[i].topAnchor.constraint(equalTo: childView[0].topAnchor).isActive = true
+                viewCGRECT = CGRect(x: (i - 4) * 170, y: 280, width: 140, height: 200)
             }
-            BeverageButtons[i].tag = i
-            BeverageButtons[i].addTarget(self, action: #selector(addBeverage(sender:)), for: .touchUpInside)
+            let stockview : StockView = StockView.init(frame: viewCGRECT, ImageName: StockView.stockTitle.allCases[i])
+            stockview.setaddButtontag(tag: i)
+            stockview.setpurchaseButtontag(tag: i)
+            stockViews.append(stockview)
+            view.addSubview(stockview)
         }
     }
     
-    func addButtonTo(parentView : UIView, constraintView : UIView, buttonTitle : String, constant: CGFloat) -> UIButton{
-        let tempBeverageBtn : UIButton = UIButton()
-        tempBeverageBtn.setTitle(buttonTitle, for: .normal)
-        tempBeverageBtn.setTitleColor(.systemBlue, for: .normal)
-        parentView.addSubview(tempBeverageBtn)
-        tempBeverageBtn.translatesAutoresizingMaskIntoConstraints = false
-        tempBeverageBtn.widthAnchor.constraint(equalToConstant: 50).isActive = true
-        tempBeverageBtn.heightAnchor.constraint(equalToConstant: 25).isActive = true
-        tempBeverageBtn.centerXAnchor.constraint(equalTo: constraintView.centerXAnchor).isActive = true
-        tempBeverageBtn.topAnchor.constraint(equalTo: constraintView.topAnchor, constant: constant).isActive = true
-        return tempBeverageBtn
-    }
     
-    func addImageTo(parentView : UIView, constraintView : UIView, imageName: String) -> UIImageView{
-        let tempBeverageImage : UIImageView = UIImageView(image: UIImage(named: imageName))
-        tempBeverageImage.backgroundColor = .white
-        tempBeverageImage.widthAnchor.constraint(equalToConstant: 140).isActive = true
-        tempBeverageImage.heightAnchor.constraint(equalToConstant: 100).isActive = true
-        parentView.addSubview(tempBeverageImage)
-        tempBeverageImage.translatesAutoresizingMaskIntoConstraints = false
-        tempBeverageImage.centerXAnchor.constraint(equalTo: constraintView.centerXAnchor).isActive = true
-        tempBeverageImage.topAnchor.constraint(equalTo: constraintView.bottomAnchor, constant: 5).isActive = true
-        tempBeverageImage.contentMode = .scaleAspectFit
-        tempBeverageImage.layer.cornerRadius = 10
-        return tempBeverageImage
-    }
-    
-    func addLabelTo(parentView : UIView, constraintView : UIView) -> UILabel{
-        let tempstockLabel : UILabel = UILabel()
-        tempstockLabel.text = "0개"
-        tempstockLabel.textAlignment = .center
-        parentView.addSubview(tempstockLabel)
-        tempstockLabel.translatesAutoresizingMaskIntoConstraints = false
-        tempstockLabel.widthAnchor.constraint(equalToConstant: 50).isActive = true
-        tempstockLabel.heightAnchor.constraint(equalToConstant: 25).isActive = true
-        tempstockLabel.centerXAnchor.constraint(equalTo: constraintView.centerXAnchor).isActive = true
-        tempstockLabel.topAnchor.constraint(equalTo: constraintView.bottomAnchor, constant: 5).isActive = true
-        return tempstockLabel
-    }
-    
-    func initChildView(imageName : String) -> UIView{
-        let tempChildView : UIView = UIView()
-        tempChildView.translatesAutoresizingMaskIntoConstraints = false
-        tempChildView.widthAnchor.constraint(equalToConstant: 150).isActive = true
-        tempChildView.heightAnchor.constraint(equalToConstant: 200).isActive = true
-        let tempBtn : UIButton = addButtonTo(parentView: tempChildView, constraintView: tempChildView, buttonTitle: "추가", constant: 5)
-        BeverageButtons.append(tempBtn)
-        let tempImage : UIImageView = addImageTo(parentView: tempChildView, constraintView: tempBtn, imageName: imageName)
-        beverageImageViews.append(tempImage)
-        let tempStockLabel : UILabel = addLabelTo(parentView: tempChildView, constraintView: tempImage)
-        stockLabel.append(tempStockLabel)
-        let _ : UIButton = addButtonTo(parentView: tempChildView, constraintView: tempStockLabel, buttonTitle: "구입", constant: 30)
-        return tempChildView
-    }
-    
-    func initMoneyaddButtons(){
-        for i in 0..<2 {
-            MoneyaddButtons.append(UIButton())
-            MoneyaddButtons[i].translatesAutoresizingMaskIntoConstraints = false
-            view.addSubview(MoneyaddButtons[i])
-            MoneyaddButtons[i].setTitleColor(.systemBlue, for: .normal)
-            MoneyaddButtons[i].widthAnchor.constraint(equalToConstant: 75).isActive = true
-            MoneyaddButtons[i].heightAnchor.constraint(equalToConstant: 50).isActive = true
-            MoneyaddButtons[i].centerYAnchor.constraint(equalTo: childView[0].centerYAnchor).isActive = true
-            MoneyaddButtons[i].tag = i
-            MoneyaddButtons[i].addTarget(self, action: #selector(addMoney(sender:)), for: .touchUpInside)
-        }
-        MoneyaddButtons[0].leftAnchor.constraint(equalTo: childView[3].rightAnchor, constant: 35).isActive = true
-        MoneyaddButtons[1].leftAnchor.constraint(equalTo: MoneyaddButtons[0].rightAnchor, constant: 25).isActive = true
-        MoneyaddButtons[0].setTitle("+1000원", for: .normal)
-        MoneyaddButtons[1].setTitle("+5000원", for: .normal)
-    }
-    
-    func initCurrentMoneyLabel() -> Void {
-        currentMoneyLabel.text = "0원"
-        currentMoneyLabel.textAlignment = .center
-        currentMoneyLabel.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(currentMoneyLabel)
-        currentMoneyLabel.widthAnchor.constraint(equalToConstant: 75).isActive = true
-        currentMoneyLabel.heightAnchor.constraint(equalToConstant: 50).isActive = true
-        currentMoneyLabel.leftAnchor.constraint(equalTo: MoneyaddButtons[0].centerXAnchor).isActive = true
-        currentMoneyLabel.centerYAnchor.constraint(equalTo: MoneyaddButtons[0].bottomAnchor, constant: 30).isActive = true
-    }
+//    func drawboughtList(beverageImage : UIImageView){
+//        boughtList.append(beverageImage)
+//        for i in 0..<boughtList.count{
+//            if i == 0{
+//                boughtList[i].leftAnchor.constraint(equalTo: view.leftAnchor, constant: 100).isActive = true
+//                boughtList[i].centerYAnchor.constraint(equalTo: view.topAnchor, constant: 400).isActive = true
+//            }
+//            else {
+//                boughtList[i-1].leftAnchor.constraint(equalTo: boughtList[i-1].leftAnchor, constant: 20).isActive = true
+//                boughtList[i-1].leftAnchor.constraint(equalTo: boughtList[i-1].leftAnchor, constant: 20).isActive = true
+//            }
+//        }
+//    }
     
     func redrawMoneyandStock(){
-        for i in 0..<stockLabel.count{
-            stockLabel[i].text = "\(vendingMachine.drawStockLabel(beverage: vendingMachine.sendBeverageInFactory(index: i)))개"
+        for i in 0..<StockView.stockTitle.allCases.count{
+            stockViews[i].updateStocklabel(stockCount: vendingMachine.drawStockLabel(beverage: vendingMachine.sendBeverageInFactory(index: i)))
         }
-        currentMoneyLabel.text = vendingMachine.drawCurrentMoney()
-    }
-    
-    @objc func addBeverage(sender : UIButton) {
-        let tempBeverage = vendingMachine.sendBeverageInFactory(index: sender.tag)
-        vendingMachine.addBeverage(beverage: tempBeverage)
-    }
-    
-    @objc func addMoney(sender: UIButton){
-        if let tempMoney = Money.moneyUnit.init(index: sender.tag) {
-            vendingMachine.addMoney(money: Money.init(money: tempMoney))
-        }
+        //currentMoneyLabel.text = vendingMachine.drawCurrentMoney()
     }
 }

--- a/VendingMachineApp/VendingMachineApp/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/ViewController.swift
@@ -11,22 +11,26 @@ import UIKit
     private var vendingMachine : VendingMachine!
     private let appDelegate : AppDelegate
     private var stockViews : [StockView]
-    private var moneyview : MoneyView!
+    private var moneyView : MoneyView!
+    private var boughtScrollview : boughtView
     
     init() {
         self.appDelegate = UIApplication.shared.delegate as! AppDelegate
         stockViews = []
+        boughtScrollview = boughtView.init(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
         super.init(nibName: nil, bundle: nil)
     }
     
     required init?(coder: NSCoder) {
         self.appDelegate = UIApplication.shared.delegate as! AppDelegate
         stockViews = []
+        boughtScrollview = boughtView.init(frame: CGRect(x: 30, y: 550, width: 650, height: 120))
         super.init(coder: coder)
     }
     
     override func viewDidLoad() {
         NotificationCenter.default.addObserver(self, selector: #selector(receiveaddNotification), name: NSNotification.Name("redrawImageandLabel"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(drawboughtImage), name: NSNotification.Name("purchaseBeverage"), object: nil)
         self.vendingMachine = appDelegate.vendingMachine
         super.viewDidLoad()
     }
@@ -40,6 +44,11 @@ import UIKit
     
     @objc func receiveaddNotification(){
         redrawMoneyandStock()
+    }
+    
+    @objc func drawboughtImage(_ notification: Notification){
+        guard let index : Int = notification.userInfo?["ImageIndex"] as? Int else { return }
+        boughtScrollview.makeBoughtImageView(ImageTitle: StockView.stockTitle.allCases[index])
     }
     
     func drawStockViews(){
@@ -58,8 +67,9 @@ import UIKit
             view.addSubview(stockview)
         }
         let moneyViewCGRect : CGRect = CGRect(x: 750, y: 80, width: 200, height: 150)
-        moneyview = MoneyView.init(frame: moneyViewCGRect)
-        view.addSubview(moneyview)
+        moneyView = MoneyView.init(frame: moneyViewCGRect)
+        view.addSubview(moneyView)
+        view.addSubview(boughtScrollview)
     }
     
     
@@ -81,6 +91,6 @@ import UIKit
         for i in 0..<StockView.stockTitle.allCases.count{
             stockViews[i].updateStocklabel(stockCount: vendingMachine.drawStockLabel(beverage: vendingMachine.sendBeverageInFactory(index: i)))
         }
-        moneyview.updateMoeny(money: vendingMachine.drawCurrentMoney())
+        moneyView.updateMoeny(money: vendingMachine.drawCurrentMoney())
     }
 }

--- a/VendingMachineApp/VendingMachineApp/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/ViewController.swift
@@ -10,121 +10,134 @@ import UIKit
 class ViewController: UIViewController {
     private var vendingMachine : VendingMachine!
     private let appDelegate : AppDelegate
+    private var childView : [UIView]
     private var BeverageButtons : [UIButton]
     private var MoneyaddButtons : [UIButton]
     private var beverageImageViews : [UIImageView]
     private var currentMoneyLabel : UILabel
     private var stockLabel : [UILabel]
+    private var buyButton : [UIButton]
     private var UIImagetitles : [String]
     
     init() {
         self.appDelegate = UIApplication.shared.delegate as! AppDelegate
+        self.childView = []
         self.BeverageButtons = []
         self.MoneyaddButtons = []
         self.beverageImageViews = []
         self.currentMoneyLabel = UILabel()
         self.stockLabel = []
+        self.buyButton = []
         self.UIImagetitles = ["BananaMilk", "StrawberryMilk", "somersby", "coke", "HOT6", "Monster", "CaffeMocha", "CafeLatte"]
         super.init(nibName: nil, bundle: nil)
     }
     
     required init?(coder: NSCoder) {
         self.appDelegate = UIApplication.shared.delegate as! AppDelegate
+        self.childView = []
         self.BeverageButtons = []
         self.MoneyaddButtons = []
         self.beverageImageViews = []
         self.currentMoneyLabel = UILabel()
         self.stockLabel = []
+        self.buyButton = []
         self.UIImagetitles = ["BananaMilk", "StrawberryMilk", "somersby", "coke", "HOT6", "Monster", "CaffeMocha", "CafeLatte"]
         super.init(coder: coder)
     }
     
     override func viewDidLoad() {
-        NotificationCenter.default.addObserver(self, selector: #selector(didReceiveTestNotification), name: NSNotification.Name("addSomething"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(receiveaddNotification), name: NSNotification.Name("addSomething"), object: nil)
         self.vendingMachine = appDelegate.vendingMachine
         super.viewDidLoad()
     }
     
     override func viewWillAppear(_ animated: Bool) {
-        initBeverageButtons()
-        initBeverageImages()
-        initvendingMachineBeverageLabels()
+        drawstockViews()
         initMoneyaddButtons()
         initCurrentMoneyLabel()
         redrawMoneyandStock()
         super.viewWillAppear(false)
     }
     
-    func addbeverageaddButton(index : Int) {
-        BeverageButtons[index].setTitle("추가", for: .normal)
-        BeverageButtons[index].setTitleColor(.systemBlue, for: .normal)
-        view.addSubview(BeverageButtons[index])
-        BeverageButtons[index].translatesAutoresizingMaskIntoConstraints = false
-        BeverageButtons[index].widthAnchor.constraint(equalToConstant: 100).isActive = true
-        BeverageButtons[index].heightAnchor.constraint(equalToConstant: 50).isActive = true
-    }
-    
-    @objc func didReceiveTestNotification(){
+    @objc func receiveaddNotification(){
         redrawMoneyandStock()
     }
     
-    func initBeverageButtons(){
-        for _ in 0..<UIImagetitles.count{
-            BeverageButtons.append(UIButton())
-        }
-        for i in 0..<BeverageButtons.count{
-            if i == 0 {//standard!
-                addbeverageaddButton(index: i)
-                BeverageButtons[i].centerXAnchor.constraint(equalTo: view.leftAnchor, constant: 100).isActive = true
-                BeverageButtons[i].centerYAnchor.constraint(equalTo: view.topAnchor, constant: 100).isActive = true
+    func drawstockViews(){
+        view.backgroundColor = .systemGray3
+        for i in 0..<UIImagetitles.count{
+            childView.append(initChildView(imageName: UIImagetitles[i]))
+            view.addSubview(childView[i])
+            if i == 0 {
+                childView[i].centerXAnchor.constraint(equalTo: view.leftAnchor, constant: 100).isActive = true
+                childView[i].centerYAnchor.constraint(equalTo: view.topAnchor, constant: 150).isActive = true
             }
             else if i > 3 {
-                addbeverageaddButton(index: i)
-                BeverageButtons[i].centerXAnchor.constraint(equalTo: BeverageButtons[0].centerXAnchor, constant: 200 * CGFloat(i-4)).isActive = true
-                BeverageButtons[i].centerYAnchor.constraint(equalTo: BeverageButtons[0].bottomAnchor, constant: 300).isActive = true
+                childView[i].centerXAnchor.constraint(equalTo: childView[0].centerXAnchor, constant: 200 * CGFloat(i-4)).isActive = true
+                childView[i].centerYAnchor.constraint(equalTo: childView[0].bottomAnchor, constant: 150).isActive = true
             }
             else {
-                addbeverageaddButton(index: i)
-                BeverageButtons[i].centerXAnchor.constraint(equalTo: BeverageButtons[0].centerXAnchor, constant: 200 * CGFloat(i)).isActive = true
-                BeverageButtons[i].centerYAnchor.constraint(equalTo: view.topAnchor, constant: 100).isActive = true
+                childView[i].centerXAnchor.constraint(equalTo: childView[0].centerXAnchor, constant: 200 * CGFloat(i)).isActive = true
+                childView[i].topAnchor.constraint(equalTo: childView[0].topAnchor).isActive = true
             }
             BeverageButtons[i].tag = i
             BeverageButtons[i].addTarget(self, action: #selector(addBeverage(sender:)), for: .touchUpInside)
         }
     }
     
-    func initBeverageImages(){
-        for i in 0..<UIImagetitles.count{
-            beverageImageViews.append(UIImageView(image: UIImage(named: UIImagetitles[i])))
-        }
-        view.backgroundColor = .systemGray
-        for i in 0..<beverageImageViews.count{ //standard
-            beverageImageViews[i].backgroundColor = UIColor.white
-            view.addSubview(beverageImageViews[i])
-            beverageImageViews[i].translatesAutoresizingMaskIntoConstraints = false
-            beverageImageViews[i].widthAnchor.constraint(equalToConstant: 150).isActive = true
-            beverageImageViews[i].heightAnchor.constraint(equalToConstant: 150).isActive = true
-            beverageImageViews[i].contentMode = .scaleAspectFit
-            beverageImageViews[i].layer.cornerRadius = 10
-            beverageImageViews[i].centerXAnchor.constraint(equalTo: BeverageButtons[i].centerXAnchor).isActive = true
-            beverageImageViews[i].topAnchor.constraint(equalTo: BeverageButtons[i].centerYAnchor, constant: 30).isActive = true
-        }
+    func addButtonTo(parentView : UIView, constraintView : UIView, buttonTitle : String, constant: CGFloat) -> UIButton{
+        let tempBeverageBtn : UIButton = UIButton()
+        tempBeverageBtn.setTitle(buttonTitle, for: .normal)
+        tempBeverageBtn.setTitleColor(.systemBlue, for: .normal)
+        parentView.addSubview(tempBeverageBtn)
+        tempBeverageBtn.translatesAutoresizingMaskIntoConstraints = false
+        tempBeverageBtn.widthAnchor.constraint(equalToConstant: 50).isActive = true
+        tempBeverageBtn.heightAnchor.constraint(equalToConstant: 25).isActive = true
+        tempBeverageBtn.centerXAnchor.constraint(equalTo: constraintView.centerXAnchor).isActive = true
+        tempBeverageBtn.topAnchor.constraint(equalTo: constraintView.topAnchor, constant: constant).isActive = true
+        return tempBeverageBtn
     }
     
-    func initvendingMachineBeverageLabels(){
-        for _ in 0..<UIImagetitles.count{
-            stockLabel.append(UILabel())
-        }
-        for i in 0..<stockLabel.count{
-            stockLabel[i].text = "0개"
-            stockLabel[i].textAlignment = .center
-            stockLabel[i].translatesAutoresizingMaskIntoConstraints = false
-            view.addSubview(stockLabel[i])
-            stockLabel[i].widthAnchor.constraint(equalToConstant: 50).isActive = true
-            stockLabel[i].heightAnchor.constraint(equalToConstant: 25).isActive = true
-            stockLabel[i].centerXAnchor.constraint(equalTo: beverageImageViews[i].centerXAnchor).isActive = true
-            stockLabel[i].topAnchor.constraint(equalTo: beverageImageViews[i].bottomAnchor, constant: 10).isActive = true
-        }
+    func addImageTo(parentView : UIView, constraintView : UIView, imageName: String) -> UIImageView{
+        let tempBeverageImage : UIImageView = UIImageView(image: UIImage(named: imageName))
+        tempBeverageImage.backgroundColor = .white
+        tempBeverageImage.widthAnchor.constraint(equalToConstant: 140).isActive = true
+        tempBeverageImage.heightAnchor.constraint(equalToConstant: 100).isActive = true
+        parentView.addSubview(tempBeverageImage)
+        tempBeverageImage.translatesAutoresizingMaskIntoConstraints = false
+        tempBeverageImage.centerXAnchor.constraint(equalTo: constraintView.centerXAnchor).isActive = true
+        tempBeverageImage.topAnchor.constraint(equalTo: constraintView.bottomAnchor, constant: 5).isActive = true
+        tempBeverageImage.contentMode = .scaleAspectFit
+        tempBeverageImage.layer.cornerRadius = 10
+        return tempBeverageImage
+    }
+    
+    func addLabelTo(parentView : UIView, constraintView : UIView) -> UILabel{
+        let tempstockLabel : UILabel = UILabel()
+        tempstockLabel.text = "0개"
+        tempstockLabel.textAlignment = .center
+        parentView.addSubview(tempstockLabel)
+        tempstockLabel.translatesAutoresizingMaskIntoConstraints = false
+        tempstockLabel.widthAnchor.constraint(equalToConstant: 50).isActive = true
+        tempstockLabel.heightAnchor.constraint(equalToConstant: 25).isActive = true
+        tempstockLabel.centerXAnchor.constraint(equalTo: constraintView.centerXAnchor).isActive = true
+        tempstockLabel.topAnchor.constraint(equalTo: constraintView.bottomAnchor, constant: 5).isActive = true
+        return tempstockLabel
+    }
+    
+    func initChildView(imageName : String) -> UIView{
+        let tempChildView : UIView = UIView()
+        tempChildView.translatesAutoresizingMaskIntoConstraints = false
+        tempChildView.widthAnchor.constraint(equalToConstant: 150).isActive = true
+        tempChildView.heightAnchor.constraint(equalToConstant: 200).isActive = true
+        let tempBtn : UIButton = addButtonTo(parentView: tempChildView, constraintView: tempChildView, buttonTitle: "추가", constant: 5)
+        BeverageButtons.append(tempBtn)
+        let tempImage : UIImageView = addImageTo(parentView: tempChildView, constraintView: tempBtn, imageName: imageName)
+        beverageImageViews.append(tempImage)
+        let tempStockLabel : UILabel = addLabelTo(parentView: tempChildView, constraintView: tempImage)
+        stockLabel.append(tempStockLabel)
+        let _ : UIButton = addButtonTo(parentView: tempChildView, constraintView: tempStockLabel, buttonTitle: "구입", constant: 30)
+        return tempChildView
     }
     
     func initMoneyaddButtons(){
@@ -135,11 +148,11 @@ class ViewController: UIViewController {
             MoneyaddButtons[i].setTitleColor(.systemBlue, for: .normal)
             MoneyaddButtons[i].widthAnchor.constraint(equalToConstant: 75).isActive = true
             MoneyaddButtons[i].heightAnchor.constraint(equalToConstant: 50).isActive = true
-            MoneyaddButtons[i].topAnchor.constraint(equalTo: beverageImageViews[0].topAnchor).isActive = true
+            MoneyaddButtons[i].centerYAnchor.constraint(equalTo: childView[0].centerYAnchor).isActive = true
             MoneyaddButtons[i].tag = i
             MoneyaddButtons[i].addTarget(self, action: #selector(addMoney(sender:)), for: .touchUpInside)
         }
-        MoneyaddButtons[0].leftAnchor.constraint(equalTo: beverageImageViews[3].rightAnchor, constant: 35).isActive = true
+        MoneyaddButtons[0].leftAnchor.constraint(equalTo: childView[3].rightAnchor, constant: 35).isActive = true
         MoneyaddButtons[1].leftAnchor.constraint(equalTo: MoneyaddButtons[0].rightAnchor, constant: 25).isActive = true
         MoneyaddButtons[0].setTitle("+1000원", for: .normal)
         MoneyaddButtons[1].setTitle("+5000원", for: .normal)
@@ -153,7 +166,7 @@ class ViewController: UIViewController {
         currentMoneyLabel.widthAnchor.constraint(equalToConstant: 75).isActive = true
         currentMoneyLabel.heightAnchor.constraint(equalToConstant: 50).isActive = true
         currentMoneyLabel.leftAnchor.constraint(equalTo: MoneyaddButtons[0].centerXAnchor).isActive = true
-        currentMoneyLabel.centerYAnchor.constraint(equalTo: MoneyaddButtons[0].bottomAnchor, constant: 20).isActive = true
+        currentMoneyLabel.centerYAnchor.constraint(equalTo: MoneyaddButtons[0].bottomAnchor, constant: 30).isActive = true
     }
     
     func redrawMoneyandStock(){


### PR DESCRIPTION
### step5,6 작업목록

- [x] viewController에 옵저버 등록
- [x] 음식 재고가 바뀌는 notification을 받으면 화면에 label 업데이트
- [x] 추가할 때마다 NotificationCenter에 post한다.
- [x] 구매 목록에 대한 제품 이미지뷰를 동적으로 추가한다
- [x] 실행 이후 구매 목록 화면 아래 이밎로 추가한다
- [x] 추가해도 계속 스크롤할 수 있어야 한다.
- [x] 특정 제품을 구매할 때 마다 제품 이미지를 추가하도록 구현한다.
- [ ] 앱을 처음 실행할 때, 구매한 품목을 불러온다
- [ ] 구매할 때 금액이 감소한다.

### 학습 키워드

* notificationCenter
* ScrollView
* view 관련 뷰 묶어서 하위뷰로 정의 후 하위 뷰 생성

### 고민과 해결

* 하위뷰로 만들어서 처리할 때 하위뷰로 정의한 클래스가 vendingMachine을 모르게 하고 싶어서 viewController에 objc 메소드를 정의하고 매개변수 seletor를 넘겨주려고 하였습니다. 어떠한 이유 때문인지 #selector는 매개변수로 넘어가지 않았습니다. 이 부분을 해결하지 못하여 하위뷰에 모두 vendingMachine을 알려주어서 해결하였습니다.

### 질문 사항

* 고민과 해결 과정에서 이렇게 해결한 것이 다소 어색하다고 생각 되는데, 어떠한 점이 잘못돼서 어색함을 느끼고 있는 지 잘모르겠습니다. 저번에 피드백 주신 내용 중에 상위 타입에 있는 속성을 참조하는 것이 위험하다고 하신 내용이 있어서, 이 때문에 어색함을 느끼고 있다고 생각되는 데 개선 방법을 찾지 못했습니다. 개선하기 위한 키워드를 질문 드리고 싶습니다. 

### 부연 설명

자판기 마지막날이 끝나기 전에 PR을 보내고 피드백을 확인하고자 주신 부분 중에 전 단계에서 개선하지 못한 부분이 있습니다.
혹시 중복된 피드백이 생길까봐. 아래의 내용과 함께 PR 보냅니다.

* 앱 저장하는 시기의 구분.
* button.tag 값을 사용하지 않고 버튼 인스턴스를 사용하여 문제를 해결하는 부분.
* viewcontroller에서 상위타입의 속성을 참조하는 부분.