### PR TITLE
[Hong] Step6 - UIScrollView, SceneDelegate에서 rootViewController 접근하기

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@
 #### 완료날짜: 2021년 3월 15일(월) 18: 15
 
 
-# 관찰자(Observer) 패턴
+# 앱 생명주기와 객체 저장
 
 #### 요구사항
 
@@ -108,3 +108,56 @@ sceneDidBecomeActive
 
 #### 완료날짜: 2021년 3월 18일(목) 23: 15
 
+
+
+# 관찰자(Observer) 패턴
+
+#### 요구사항
+
+- ViewController는 viewDidLoad에서 Observe를 등록한다.
+- 음식 재고가 바뀌는 Notification을 받으면 화면에 Label을 업데이트한다.
+- 추가 버튼을 누르면 해당 음식 재고를 모델에 추가할 때마다
+- VendingMachine 모델 객체에서는 변화에 대해 NotificationCenter에 post한다.
+- 모든 동작은 이전 단계와 동일하게 동작해야 한다.
+
+#### 학습
+
+- Notification
+
+  > Notification.post -> observer가 수신받음
+
+
+
+#### 완료날짜: 2021년 3월 20일(금) 22:40 
+
+# 구매목록 View 코드
+
+
+
+#### 요구사항
+
+- 실행이후 구매 목록을 화면 아래 이미지로 추가한다.
+- 화면 아래 부분을 좌우로 스크롤 가능하도록 만들고 상품 이미지를 추가한다. 계속 추가해도 스크롤할 수 있어야 한다.
+- 특정 제품을 구매할 때마다 해당 제품 이미지를 추가하도록 구현한다.
+  - NotificationCenter를 활용하자!
+- 특정 시점에 `self.scrollView.addSubView()` 메서드로 UIImageView를 수동 추가한다.
+
+
+
+#### 학습
+
+- UIScrollView
+
+- SceneDelegate에서 rootViewController 접근하는법 (상위모듈 -> 하위모듈 속성값 인스턴스 넣어주기)
+
+  >    **guard** **let** initialViewController = window?.rootViewController **as**? ViewController **else** { **return** }
+  >
+  > ​    initialViewController.vendingMachine = vendingMachine
+
+
+
+![ezgif com-gif-maker (6)](https://user-images.githubusercontent.com/73683735/111974755-208b4580-8b43-11eb-87e8-30b1049793aa.gif)
+
+
+
+#### 완료날짜: 2021년 3월 22일(월) 19: 08

--- a/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
+++ b/VendingMachineApp/VendingMachineApp.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		1E0505A225F202450082FAB4 /* Beverages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E0505A125F202450082FAB4 /* Beverages.swift */; };
 		1E0505A725F20AE10082FAB4 /* Beverages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E0505A125F202450082FAB4 /* Beverages.swift */; };
+		1E34E5522607C65D00EA9AD7 /* PurchasedItemListScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E34E5512607C65D00EA9AD7 /* PurchasedItemListScrollView.swift */; };
 		1E3B48C625EE759000903D6E /* PurchaseHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E3B48C525EE759000903D6E /* PurchaseHistory.swift */; };
 		1E3B48CA25EE895700903D6E /* PaymentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E3B48C925EE895700903D6E /* PaymentManager.swift */; };
 		1E3B48D425EF63C200903D6E /* VendingMachineAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E3B48D325EF63C200903D6E /* VendingMachineAppTests.swift */; };
@@ -61,6 +62,7 @@
 
 /* Begin PBXFileReference section */
 		1E0505A125F202450082FAB4 /* Beverages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Beverages.swift; sourceTree = "<group>"; };
+		1E34E5512607C65D00EA9AD7 /* PurchasedItemListScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasedItemListScrollView.swift; sourceTree = "<group>"; };
 		1E3B48C525EE759000903D6E /* PurchaseHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseHistory.swift; sourceTree = "<group>"; };
 		1E3B48C925EE895700903D6E /* PaymentManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentManager.swift; sourceTree = "<group>"; };
 		1E3B48D125EF63C200903D6E /* VendingMachineAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = VendingMachineAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -214,6 +216,7 @@
 			children = (
 				1ED19CDB25F75D060047B97A /* BeverageView.swift */,
 				1E6A36F225FA5F9800A81643 /* BeverageView.xib */,
+				1E34E5512607C65D00EA9AD7 /* PurchasedItemListScrollView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -351,6 +354,7 @@
 				1E0505A225F202450082FAB4 /* Beverages.swift in Sources */,
 				1E3D23B125E6A9680096DE7B /* Top.swift in Sources */,
 				1E3D23B925E79D310096DE7B /* Date.swift in Sources */,
+				1E34E5522607C65D00EA9AD7 /* PurchasedItemListScrollView.swift in Sources */,
 				1E3D238025E688D30096DE7B /* AppDelegate.swift in Sources */,
 				1E3B48CA25EE895700903D6E /* PaymentManager.swift in Sources */,
 				1E3B48C625EE759000903D6E /* PurchaseHistory.swift in Sources */,

--- a/VendingMachineApp/VendingMachineApp/AppDelegate.swift
+++ b/VendingMachineApp/VendingMachineApp/AppDelegate.swift
@@ -9,12 +9,8 @@ import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
-    var vendingMachine: VendingMachine!
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        
-        self.vendingMachine = ArchivingManager.loadData(forKey: "vendingMachine")
         
         return true
     }

--- a/VendingMachineApp/VendingMachineApp/Base.lproj/Main.storyboard
+++ b/VendingMachineApp/VendingMachineApp/Base.lproj/Main.storyboard
@@ -47,7 +47,7 @@
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </view>
                             <stackView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="GyI-fo-vUe">
-                                <rect key="frame" x="91" y="148" width="641" height="120"/>
+                                <rect key="frame" x="91" y="148" width="641" height="244"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             </stackView>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5ZE-yd-1d9">

--- a/VendingMachineApp/VendingMachineApp/Base.lproj/Main.storyboard
+++ b/VendingMachineApp/VendingMachineApp/Base.lproj/Main.storyboard
@@ -50,6 +50,12 @@
                                 <rect key="frame" x="91" y="148" width="641" height="120"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             </stackView>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5ZE-yd-1d9">
+                                <rect key="frame" x="91" y="496" width="641" height="128"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <viewLayoutGuide key="contentLayoutGuide" id="Lhp-L9-tP6"/>
+                                <viewLayoutGuide key="frameLayoutGuide" id="Osu-dW-9jY"/>
+                            </scrollView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -57,6 +63,7 @@
                     <connections>
                         <outlet property="inventoryStackView" destination="GyI-fo-vUe" id="2SF-5x-DJI"/>
                         <outlet property="moneyLabel" destination="Qo9-cC-8x5" id="k1Q-LZ-NGR"/>
+                        <outlet property="purchasedBeverageScrollView" destination="5ZE-yd-1d9" id="FRO-qS-aef"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/VendingMachineApp/VendingMachineApp/Base.lproj/Main.storyboard
+++ b/VendingMachineApp/VendingMachineApp/Base.lproj/Main.storyboard
@@ -50,7 +50,7 @@
                                 <rect key="frame" x="91" y="148" width="641" height="244"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             </stackView>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5ZE-yd-1d9">
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5ZE-yd-1d9" customClass="PurchasedItemListScrollView" customModule="VendingMachineApp" customModuleProvider="target">
                                 <rect key="frame" x="91" y="496" width="641" height="128"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <viewLayoutGuide key="contentLayoutGuide" id="Lhp-L9-tP6"/>
@@ -63,7 +63,7 @@
                     <connections>
                         <outlet property="inventoryStackView" destination="GyI-fo-vUe" id="2SF-5x-DJI"/>
                         <outlet property="moneyLabel" destination="Qo9-cC-8x5" id="k1Q-LZ-NGR"/>
-                        <outlet property="purchasedBeverageScrollView" destination="5ZE-yd-1d9" id="FRO-qS-aef"/>
+                        <outlet property="purchasedBeverageScrollView" destination="5ZE-yd-1d9" id="ydg-VX-VSi"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/VendingMachineApp/VendingMachineApp/Controller/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/Controller/ViewController.swift
@@ -23,6 +23,8 @@ class ViewController: UIViewController {
 
         NotificationCenter.default.addObserver(self, selector: #selector(updateBeverageStockLabel), name: NSNotification.Name("addedBeverage"), object: vendingMachine)
         NotificationCenter.default.addObserver(self, selector: #selector(updateMoneyLabel), name: NSNotification.Name("addMoney"), object: vendingMachine)
+        NotificationCenter.default.addObserver(self, selector: #selector(updateBeverageStockLabel), name: NSNotification.Name("buyBeverage"), object: vendingMachine)
+        NotificationCenter.default.addObserver(self, selector: #selector(updateMoneyLabel), name: NSNotification.Name("buyBeverage"), object: vendingMachine)
     }
     
     private func setUpInventoryStackView() {
@@ -42,23 +44,36 @@ class ViewController: UIViewController {
     @IBAction
     func addBeverage(_ sender: UIButton) {
         
-        guard let beverageType = vendingMachineInfo.beverageTypeButtons[sender] else {
+        guard let beverageType = vendingMachineInfo.beverageTypeAddButtons[sender] else {
             return
         }
 
         vendingMachine.appendInventory(beverageType.init())
     }
     
+    //BeverageView - buyButton의 First Responder로 설정
+    @IBAction
+    func buyBeverage(_ sender: UIButton) {
+        
+        guard let beverageType = vendingMachineInfo.beverageTypeBuyButtons[sender] else {
+            return
+        }
+
+        vendingMachine.buy(beverageType)
+    }
+    
     @objc
     private func updateBeverageStockLabel(notification: Notification) {
 
-        guard let beverageType = notification.userInfo as? [ObjectIdentifier:[Beverage]] else {
-            return
-        }
-        beverageType.keys.forEach { objectIdentifier in
-            vendingMachineInfo.matchModelAndViewHelper[objectIdentifier]?.stockLabel.text = "\(beverageType[objectIdentifier]?.count ?? 0)"
+        let vendingMachine = notification.object as! VendingMachine
+       
+        vendingMachineInfo.matchModelAndViewHelper.forEach { (arg0) in
+            
+            let (objectIdentifier, beverageView) = arg0
+            beverageView.stockLabel.text = "\(vendingMachine.showAllBeverageList()[objectIdentifier]?.count ?? 0)"
         }
     }
+    
     
     @IBAction func addMoney5000(_ sender: Any) {
         vendingMachine.put(in: .fiveThousand)

--- a/VendingMachineApp/VendingMachineApp/Controller/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/Controller/ViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 class ViewController: UIViewController {
     
     @IBOutlet weak var inventoryStackView: UIStackView!
+    @IBOutlet weak var purchasedBeverageScrollView: UIScrollView!
     @IBOutlet weak var moneyLabel: UILabel!
     
     var delegate: AppDelegate = UIApplication.shared.delegate as! AppDelegate

--- a/VendingMachineApp/VendingMachineApp/Controller/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/Controller/ViewController.swift
@@ -13,9 +13,9 @@ class ViewController: UIViewController {
     @IBOutlet weak var purchasedBeverageScrollView: UIScrollView!
     @IBOutlet weak var moneyLabel: UILabel!
     
-    var delegate: AppDelegate = UIApplication.shared.delegate as! AppDelegate
+    var vendingMachine: VendingMachine!
     
-    private lazy var vendingMachineInfo = VendingMachineInfo(with: delegate.vendingMachine)
+    private lazy var vendingMachineInfo = VendingMachineInfo(with: vendingMachine)
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -49,7 +49,7 @@ class ViewController: UIViewController {
         guard let beverageType = vendingMachineInfo.beverageTypeButtons[button] else {
             return
         }
-        delegate.vendingMachine.appendInventory(beverageType.init())
+        vendingMachine.appendInventory(beverageType.init())
     }
     
     @objc
@@ -64,10 +64,10 @@ class ViewController: UIViewController {
     }
     
     @IBAction func addMoney5000(_ sender: Any) {
-        delegate.vendingMachine.put(in: .fiveThousand)
+        vendingMachine.put(in: .fiveThousand)
     }
     
     @IBAction func addMoney1000(_ sender: Any) {
-        delegate.vendingMachine.put(in: .thousand)
+        vendingMachine.put(in: .thousand)
     }
 }

--- a/VendingMachineApp/VendingMachineApp/Controller/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/Controller/ViewController.swift
@@ -22,8 +22,8 @@ class ViewController: UIViewController {
         setUpInventoryStackView()
 
         NotificationCenter.default.addObserver(self, selector: #selector(addBeverage), name: NSNotification.Name("didTapBeverageButton"), object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(updateBeverageStockLabel), name: NSNotification.Name("addedBeverage"), object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(updateMoneyLabel), name: NSNotification.Name("addMoney"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(updateBeverageStockLabel), name: NSNotification.Name("addedBeverage"), object: vendingMachine)
+        NotificationCenter.default.addObserver(self, selector: #selector(updateMoneyLabel), name: NSNotification.Name("addMoney"), object: vendingMachine)
     }
     
     private func setUpInventoryStackView() {
@@ -34,21 +34,19 @@ class ViewController: UIViewController {
     
     @objc
     private func updateMoneyLabel(notification: Notification) {
-        guard let vendingMachine = notification.object as? VendingMachine else {
-            return
-        }
+        let vendingMachine = notification.object as! VendingMachine
+      
         moneyLabel.text = "잔액: \(vendingMachine.showCurrentMoney()) 원"
     }
     
     @objc
     private func addBeverage(notification: Notification) {
         
-        guard let button = notification.object as? UIButton else {
+        guard let button = notification.object as? UIButton,
+              let beverageType = vendingMachineInfo.beverageTypeButtons[button] else {
             return
         }
-        guard let beverageType = vendingMachineInfo.beverageTypeButtons[button] else {
-            return
-        }
+
         vendingMachine.appendInventory(beverageType.init())
     }
     

--- a/VendingMachineApp/VendingMachineApp/Controller/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/Controller/ViewController.swift
@@ -13,6 +13,7 @@ class ViewController: UIViewController {
     @IBOutlet weak var purchasedBeverageScrollView: PurchasedItemListScrollView!
     @IBOutlet weak var moneyLabel: UILabel!
     
+    //TODO:- VendingMachine타입이 아니라 프로토콜로 수정
     var vendingMachine: VendingMachine!
     
     private lazy var vendingMachineInfo = VendingMachineInfo(with: vendingMachine)
@@ -22,6 +23,7 @@ class ViewController: UIViewController {
         setUpInventoryStackView()
         setUpPurchasedBeverageScrollView()
         
+        //TODO:- name을 VendingMachine Class에 enum타입으로 추가
         NotificationCenter.default.addObserver(self, selector: #selector(updateBeverageStockLabel), name: NSNotification.Name("addedBeverage"), object: vendingMachine)
         NotificationCenter.default.addObserver(self, selector: #selector(updateMoneyLabel), name: NSNotification.Name("addMoney"), object: vendingMachine)
         NotificationCenter.default.addObserver(self, selector: #selector(updateBeverageStockLabel), name: NSNotification.Name("buyBeverage"), object: vendingMachine)
@@ -36,7 +38,7 @@ class ViewController: UIViewController {
     }
     
     private func setUpPurchasedBeverageScrollView() {
-        vendingMachine.beverageListForPurchase().forEach { beverage in
+        vendingMachine.showPurchaseHistory().forEach { beverage in
             let beverageImage = vendingMachineInfo.matchModelAndViewHelper[ObjectIdentifier(type(of: beverage))]?.imageView.image
             purchasedBeverageScrollView.addImageView(image: beverageImage ?? UIImage())
         }
@@ -94,6 +96,7 @@ class ViewController: UIViewController {
         }
     }
     
+    //TODO:- sender를 이용하여 잔액 추가하도록 수정
     @IBAction func addMoney5000(_ sender: Any) {
         vendingMachine.put(in: .fiveThousand)
     }

--- a/VendingMachineApp/VendingMachineApp/Controller/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/Controller/ViewController.swift
@@ -23,10 +23,9 @@ class ViewController: UIViewController {
         setUpInventoryStackView()
         setUpPurchasedBeverageScrollView()
         
-        //TODO:- name을 VendingMachine Class에 enum타입으로 추가
-        NotificationCenter.default.addObserver(self, selector: #selector(updateBeverageStockLabel), name: NSNotification.Name("addedBeverage"), object: vendingMachine)
-        NotificationCenter.default.addObserver(self, selector: #selector(updateMoneyLabel), name: NSNotification.Name("addMoney"), object: vendingMachine)
-        NotificationCenter.default.addObserver(self, selector: #selector(addPurchasedBeverageView), name: NSNotification.Name("buyBeverage"), object: vendingMachine)
+        NotificationCenter.default.addObserver(self, selector: #selector(updateBeverageStockLabel), name: VendingMachine.addedBeverage, object: vendingMachine)
+        NotificationCenter.default.addObserver(self, selector: #selector(updateMoneyLabel), name: VendingMachine.addMoney, object: vendingMachine)
+        NotificationCenter.default.addObserver(self, selector: #selector(addPurchasedBeverageView), name: VendingMachine.buyBeverage, object: vendingMachine)
     }
     
     private func setUpInventoryStackView() {

--- a/VendingMachineApp/VendingMachineApp/Controller/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/Controller/ViewController.swift
@@ -21,7 +21,6 @@ class ViewController: UIViewController {
         super.viewDidLoad()
         setUpInventoryStackView()
 
-        NotificationCenter.default.addObserver(self, selector: #selector(addBeverage), name: NSNotification.Name("didTapBeverageButton"), object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(updateBeverageStockLabel), name: NSNotification.Name("addedBeverage"), object: vendingMachine)
         NotificationCenter.default.addObserver(self, selector: #selector(updateMoneyLabel), name: NSNotification.Name("addMoney"), object: vendingMachine)
     }
@@ -39,11 +38,11 @@ class ViewController: UIViewController {
         moneyLabel.text = "잔액: \(vendingMachine.showCurrentMoney()) 원"
     }
     
-    @objc
-    private func addBeverage(notification: Notification) {
+    //BeverageView - addButton의 First Responder로 설정
+    @IBAction
+    func addBeverage(_ sender: UIButton) {
         
-        guard let button = notification.object as? UIButton,
-              let beverageType = vendingMachineInfo.beverageTypeButtons[button] else {
+        guard let beverageType = vendingMachineInfo.beverageTypeButtons[sender] else {
             return
         }
 

--- a/VendingMachineApp/VendingMachineApp/Controller/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/Controller/ViewController.swift
@@ -21,6 +21,7 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setUpInventoryStackView()
+        setUpBeverageStockLabel()
         setUpPurchasedBeverageScrollView()
         
         NotificationCenter.default.addObserver(self, selector: #selector(updateBeverageStockLabel), name: VendingMachine.addedBeverage, object: vendingMachine)
@@ -31,6 +32,14 @@ class ViewController: UIViewController {
     private func setUpInventoryStackView() {
         vendingMachineInfo.repeatForBeverageView { beverageView in
             inventoryStackView.addArrangedSubview(beverageView)
+        }
+    }
+    
+    private func setUpBeverageStockLabel() {
+        vendingMachineInfo.matchModelAndViewHelper.forEach { (arg0) in
+            
+            let (objectIdentifier, beverageView) = arg0
+            beverageView.stockLabel.text = "\(vendingMachine.showAllBeverageList()[objectIdentifier]?.count ?? 0)"
         }
     }
     

--- a/VendingMachineApp/VendingMachineApp/Controller/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/Controller/ViewController.swift
@@ -26,8 +26,6 @@ class ViewController: UIViewController {
         //TODO:- name을 VendingMachine Class에 enum타입으로 추가
         NotificationCenter.default.addObserver(self, selector: #selector(updateBeverageStockLabel), name: NSNotification.Name("addedBeverage"), object: vendingMachine)
         NotificationCenter.default.addObserver(self, selector: #selector(updateMoneyLabel), name: NSNotification.Name("addMoney"), object: vendingMachine)
-        NotificationCenter.default.addObserver(self, selector: #selector(updateBeverageStockLabel), name: NSNotification.Name("buyBeverage"), object: vendingMachine)
-        NotificationCenter.default.addObserver(self, selector: #selector(updateMoneyLabel), name: NSNotification.Name("buyBeverage"), object: vendingMachine)
         NotificationCenter.default.addObserver(self, selector: #selector(addPurchasedBeverageView), name: NSNotification.Name("buyBeverage"), object: vendingMachine)
     }
     

--- a/VendingMachineApp/VendingMachineApp/Controller/ViewController.swift
+++ b/VendingMachineApp/VendingMachineApp/Controller/ViewController.swift
@@ -13,15 +13,14 @@ class ViewController: UIViewController {
     @IBOutlet weak var purchasedBeverageScrollView: PurchasedItemListScrollView!
     @IBOutlet weak var moneyLabel: UILabel!
     
-    //TODO:- VendingMachine타입이 아니라 프로토콜로 수정
-    var vendingMachine: VendingMachine!
+    var vendingMachine: MakingViewProtocol!
     
     private lazy var vendingMachineInfo = VendingMachineInfo(with: vendingMachine)
     
     override func viewDidLoad() {
         super.viewDidLoad()
         setUpInventoryStackView()
-        setUpBeverageStockLabel()
+        setUpMoneyLabel()
         setUpPurchasedBeverageScrollView()
         
         NotificationCenter.default.addObserver(self, selector: #selector(updateBeverageStockLabel), name: VendingMachine.addedBeverage, object: vendingMachine)
@@ -35,12 +34,8 @@ class ViewController: UIViewController {
         }
     }
     
-    private func setUpBeverageStockLabel() {
-        vendingMachineInfo.matchModelAndViewHelper.forEach { (arg0) in
-            
-            let (objectIdentifier, beverageView) = arg0
-            beverageView.stockLabel.text = "\(vendingMachine.showAllBeverageList()[objectIdentifier]?.count ?? 0)"
-        }
+    private func setUpMoneyLabel() {
+        moneyLabel.text = "잔액: \(vendingMachine.showCurrentMoney()) 원"
     }
     
     private func setUpPurchasedBeverageScrollView() {

--- a/VendingMachineApp/VendingMachineApp/Model/VendingMachine.swift
+++ b/VendingMachineApp/VendingMachineApp/Model/VendingMachine.swift
@@ -53,6 +53,8 @@ class VendingMachine: NSObject, NSCoding, MakingViewProtocol {
         guard let beverage = inventory.take(out: beverageType, for: paymentManager) else { return }
         purchaseHistory.append(item: beverage)
         NotificationCenter.default.post(name: NSNotification.Name("buyBeverage"), object: self, userInfo: ["imageName":beverage.name])
+        NotificationCenter.default.post(name: NSNotification.Name("addedBeverage"), object: self, userInfo: nil)
+        NotificationCenter.default.post(name: NSNotification.Name("addMoney"), object: self, userInfo: nil)
     }
     
     //잔액을 확인하는 기능

--- a/VendingMachineApp/VendingMachineApp/Model/VendingMachine.swift
+++ b/VendingMachineApp/VendingMachineApp/Model/VendingMachine.swift
@@ -34,7 +34,7 @@ class VendingMachine: NSObject, NSCoding, MakingViewProtocol {
     //특정 상품 인스턴스를 넘겨서 재고를 추가하는 기능
     public func appendInventory(_ beverage: Beverage) {
         inventory.append(beverage)
-        NotificationCenter.default.post(name: NSNotification.Name("addedBeverage"), object: self, userInfo: nil)
+        NotificationCenter.default.post(name: VendingMachine.addedBeverage, object: self, userInfo: nil)
     }
     
     //현재 금액으로 구매가능한 음료수 목록을 리턴하는 기능
@@ -45,16 +45,16 @@ class VendingMachine: NSObject, NSCoding, MakingViewProtocol {
     //자판기 금액을 원하는 금액만큼 올리는 기능
     public func put(in money: Money) {
         paymentManager.increase(money)
-        NotificationCenter.default.post(name: NSNotification.Name("addMoney"), object: self, userInfo: nil)
+        NotificationCenter.default.post(name: VendingMachine.addMoney, object: self, userInfo: nil)
     }
     
     //음료수를 구매하는 기능
     public func buy(_ beverageType: Beverage.Type) {
         guard let beverage = inventory.take(out: beverageType, for: paymentManager) else { return }
         purchaseHistory.append(item: beverage)
-        NotificationCenter.default.post(name: NSNotification.Name("buyBeverage"), object: self, userInfo: ["imageName":beverage.name])
-        NotificationCenter.default.post(name: NSNotification.Name("addedBeverage"), object: self, userInfo: nil)
-        NotificationCenter.default.post(name: NSNotification.Name("addMoney"), object: self, userInfo: nil)
+        NotificationCenter.default.post(name: VendingMachine.buyBeverage, object: self, userInfo: ["imageName":beverage.name])
+        NotificationCenter.default.post(name: VendingMachine.addedBeverage, object: self, userInfo: nil)
+        NotificationCenter.default.post(name: VendingMachine.addMoney, object: self, userInfo: nil)
     }
     
     //잔액을 확인하는 기능
@@ -83,3 +83,8 @@ class VendingMachine: NSObject, NSCoding, MakingViewProtocol {
     }
 }
 
+extension VendingMachine {
+    static let addMoney = Notification.Name("addMoney")
+    static let buyBeverage = Notification.Name("buyBeverage")
+    static let addedBeverage = Notification.Name("addedBeverage")
+}

--- a/VendingMachineApp/VendingMachineApp/Model/VendingMachine.swift
+++ b/VendingMachineApp/VendingMachineApp/Model/VendingMachine.swift
@@ -7,7 +7,7 @@
 
 import Foundation
  
-class VendingMachine: NSObject, NSCoding, makingViewProtocol {
+class VendingMachine: NSObject, NSCoding, MakingViewProtocol {
 
     private var inventory: Inventory
     private var paymentManager: PaymentManager

--- a/VendingMachineApp/VendingMachineApp/Model/VendingMachine.swift
+++ b/VendingMachineApp/VendingMachineApp/Model/VendingMachine.swift
@@ -34,7 +34,7 @@ class VendingMachine: NSObject, NSCoding, MakingViewProtocol {
     //특정 상품 인스턴스를 넘겨서 재고를 추가하는 기능
     public func appendInventory(_ beverage: Beverage) {
         inventory.append(beverage)
-        NotificationCenter.default.post(name: NSNotification.Name("addedBeverage"), object: self, userInfo: showAllBeverageList())
+        NotificationCenter.default.post(name: NSNotification.Name("addedBeverage"), object: self, userInfo: nil)
     }
     
     //현재 금액으로 구매가능한 음료수 목록을 리턴하는 기능
@@ -52,6 +52,7 @@ class VendingMachine: NSObject, NSCoding, MakingViewProtocol {
     public func buy(_ beverageType: Beverage.Type) {
         guard let beverage = inventory.take(out: beverageType, for: paymentManager) else { return }
         purchaseHistory.append(item: beverage)
+        NotificationCenter.default.post(name: NSNotification.Name("buyBeverage"), object: self, userInfo: nil)
     }
     
     //잔액을 확인하는 기능

--- a/VendingMachineApp/VendingMachineApp/Model/VendingMachine.swift
+++ b/VendingMachineApp/VendingMachineApp/Model/VendingMachine.swift
@@ -52,7 +52,7 @@ class VendingMachine: NSObject, NSCoding, MakingViewProtocol {
     public func buy(_ beverageType: Beverage.Type) {
         guard let beverage = inventory.take(out: beverageType, for: paymentManager) else { return }
         purchaseHistory.append(item: beverage)
-        NotificationCenter.default.post(name: NSNotification.Name("buyBeverage"), object: self, userInfo: nil)
+        NotificationCenter.default.post(name: NSNotification.Name("buyBeverage"), object: self, userInfo: ["imageName":beverage.name])
     }
     
     //잔액을 확인하는 기능

--- a/VendingMachineApp/VendingMachineApp/Model/VendingMachineInfo.swift
+++ b/VendingMachineApp/VendingMachineApp/Model/VendingMachineInfo.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-protocol makingViewProtocol {
+protocol MakingViewProtocol {
     func showAllBeverageList() -> [ObjectIdentifier: [Beverage]]
 }
 
@@ -15,9 +15,9 @@ class VendingMachineInfo {
     private(set) var matchModelAndViewHelper: [ObjectIdentifier: BeverageView] = [:]
     private(set) var beverageTypeButtons: [UIButton: Beverage.Type] = [:]
 
-    private var objectforMakingView: makingViewProtocol
+    private var objectforMakingView: MakingViewProtocol
     
-    init(with objectforMakingView: makingViewProtocol) {
+    init(with objectforMakingView: MakingViewProtocol) {
         self.objectforMakingView = objectforMakingView
         self.renewVendingMachineInfo()
     }

--- a/VendingMachineApp/VendingMachineApp/Model/VendingMachineInfo.swift
+++ b/VendingMachineApp/VendingMachineApp/Model/VendingMachineInfo.swift
@@ -13,8 +13,9 @@ protocol MakingViewProtocol {
 
 class VendingMachineInfo {
     private(set) var matchModelAndViewHelper: [ObjectIdentifier: BeverageView] = [:]
-    private(set) var beverageTypeButtons: [UIButton: Beverage.Type] = [:]
-
+    private(set) var beverageTypeAddButtons: [UIButton: Beverage.Type] = [:]
+    private(set) var beverageTypeBuyButtons: [UIButton: Beverage.Type] = [:]
+    
     private var objectforMakingView: MakingViewProtocol
     
     init(with objectforMakingView: MakingViewProtocol) {
@@ -33,7 +34,8 @@ class VendingMachineInfo {
                 let beverageView =  BeverageView(beverageImage: image, stockLabelText: text )
                 
                 matchModelAndViewHelper[key] = beverageView
-                beverageTypeButtons[beverageView.addButton] = type(of: beverage)
+                beverageTypeAddButtons[beverageView.addButton] = type(of: beverage)
+                beverageTypeBuyButtons[beverageView.buyButton] = type(of: beverage)
             }
         }
     }

--- a/VendingMachineApp/VendingMachineApp/Model/VendingMachineInfo.swift
+++ b/VendingMachineApp/VendingMachineApp/Model/VendingMachineInfo.swift
@@ -9,6 +9,11 @@ import UIKit
 
 protocol MakingViewProtocol {
     func showAllBeverageList() -> [ObjectIdentifier: [Beverage]]
+    func showPurchaseHistory() -> [Beverage]
+    func put(in: Money)
+    func buy(_: Beverage.Type)
+    func appendInventory(_: Beverage)
+    func showCurrentMoney() -> Int
 }
 
 class VendingMachineInfo {

--- a/VendingMachineApp/VendingMachineApp/SceneDelegate.swift
+++ b/VendingMachineApp/VendingMachineApp/SceneDelegate.swift
@@ -35,9 +35,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func sceneWillEnterForeground(_ scene: UIScene) {
-        //TODO:- 가짜노티 제거
-        // 앱 켰을 때 초기 잔액 LabelText 변경
-        NotificationCenter.default.post(name: NSNotification.Name(rawValue: "addMoney"), object: vendingMachine, userInfo: nil)
+   
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {

--- a/VendingMachineApp/VendingMachineApp/SceneDelegate.swift
+++ b/VendingMachineApp/VendingMachineApp/SceneDelegate.swift
@@ -7,10 +7,6 @@
 
 import UIKit
 
-protocol RootViewControllerProtocol {
-    var vendingMachine: VendingMachine! { get }
-}
-
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?

--- a/VendingMachineApp/VendingMachineApp/SceneDelegate.swift
+++ b/VendingMachineApp/VendingMachineApp/SceneDelegate.swift
@@ -35,6 +35,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func sceneWillEnterForeground(_ scene: UIScene) {
+        //TODO:- 가짜노티 제거
         // 앱 켰을 때 초기 잔액 LabelText 변경
         NotificationCenter.default.post(name: NSNotification.Name(rawValue: "addMoney"), object: vendingMachine, userInfo: nil)
     }

--- a/VendingMachineApp/VendingMachineApp/SceneDelegate.swift
+++ b/VendingMachineApp/VendingMachineApp/SceneDelegate.swift
@@ -7,15 +7,23 @@
 
 import UIKit
 
+protocol RootViewControllerProtocol {
+    var vendingMachine: VendingMachine! { get }
+}
+
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
-
+    var vendingMachine: VendingMachine!
+    
     var appDelegate = UIApplication.shared.delegate as! AppDelegate
     
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        guard let initialViewController = window?.rootViewController as? ViewController else { return }
+       
+        self.vendingMachine = ArchivingManager.loadData(forKey: "vendingMachine")
         
-        guard let _ = (scene as? UIWindowScene) else { return }
+        initialViewController.vendingMachine = vendingMachine
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {
@@ -27,12 +35,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func sceneWillResignActive(_ scene: UIScene) {
-        ArchivingManager.save(data: appDelegate.vendingMachine, forkey: "vendingMachine")
+        ArchivingManager.save(data: vendingMachine, forkey: "vendingMachine")
     }
 
     func sceneWillEnterForeground(_ scene: UIScene) {
         // 앱 켰을 때 초기 잔액 LabelText 변경
-        NotificationCenter.default.post(name: NSNotification.Name(rawValue: "addMoney"), object: appDelegate.vendingMachine, userInfo: nil)
+        NotificationCenter.default.post(name: NSNotification.Name(rawValue: "addMoney"), object: vendingMachine, userInfo: nil)
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {

--- a/VendingMachineApp/VendingMachineApp/View/BeverageView.swift
+++ b/VendingMachineApp/VendingMachineApp/View/BeverageView.swift
@@ -27,17 +27,15 @@ class BeverageView: UIView {
     
     convenience init(beverageImage: UIImage, stockLabelText: String) {
         self.init()
+        configureView()
         imageView.image = beverageImage
         stockLabel.text = stockLabelText
+       
     }
     
     private func configureView() {
         self.loadViewFromNib(nibName: nibName)
         imageView.layer.cornerRadius = 25.0
         imageView.layer.masksToBounds = true
-    }
-    
-    @IBAction func didTapAddBeverageButton(_ sender: UIButton) {
-        NotificationCenter.default.post(name: NSNotification.Name("didTapBeverageButton"), object: sender, userInfo: nil)
     }
 }

--- a/VendingMachineApp/VendingMachineApp/View/BeverageView.swift
+++ b/VendingMachineApp/VendingMachineApp/View/BeverageView.swift
@@ -13,6 +13,7 @@ class BeverageView: UIView {
     @IBOutlet weak var addButton: UIButton!
     @IBOutlet weak var imageView: UIImageView!
     @IBOutlet weak var stockLabel: UILabel!
+    @IBOutlet weak var buyButton: UIButton!
     
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/VendingMachineApp/VendingMachineApp/View/BeverageView.xib
+++ b/VendingMachineApp/VendingMachineApp/View/BeverageView.xib
@@ -11,13 +11,14 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="BeverageView" customModule="VendingMachineApp" customModuleProvider="target">
             <connections>
                 <outlet property="addButton" destination="MWQ-ca-3jO" id="Uwm-JV-AKX"/>
+                <outlet property="buyButton" destination="1VQ-F1-JzX" id="T0M-Y7-SbR"/>
                 <outlet property="imageView" destination="xDO-zC-LfC" id="lUK-j3-ufI"/>
                 <outlet property="stockLabel" destination="0ad-UX-0V5" id="NtG-rQ-PNT"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB">
-            <rect key="frame" x="0.0" y="0.0" width="287" height="269"/>
+            <rect key="frame" x="0.0" y="0.0" width="287" height="323"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="바나나우유" translatesAutoresizingMaskIntoConstraints="NO" id="xDO-zC-LfC">
@@ -33,34 +34,54 @@
                         <action selector="didTapAddBeverageButton:" destination="-1" eventType="touchUpInside" id="H5n-ps-dAr"/>
                     </connections>
                 </button>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0ad-UX-0V5">
-                    <rect key="frame" x="0.0" y="228" width="287" height="21"/>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0ad-UX-0V5">
+                    <rect key="frame" x="0.0" y="220" width="287" height="21"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="21" id="WnQ-ji-bFz"/>
+                    </constraints>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1VQ-F1-JzX">
+                    <rect key="frame" x="0.0" y="286" width="287" height="30"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="30" id="yo5-G3-8zM"/>
+                    </constraints>
+                    <state key="normal" title="구매">
+                        <color key="titleColor" systemColor="systemPinkColor"/>
+                    </state>
+                </button>
             </subviews>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="0ad-UX-0V5" secondAttribute="trailing" id="3YS-oT-LwU"/>
                 <constraint firstItem="0ad-UX-0V5" firstAttribute="top" secondItem="xDO-zC-LfC" secondAttribute="bottom" id="BDx-Ot-afF"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="1VQ-F1-JzX" secondAttribute="bottom" constant="7" id="Dzw-uL-ipQ"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="1VQ-F1-JzX" secondAttribute="bottom" constant="7" id="HtG-JJ-VSy"/>
                 <constraint firstItem="MWQ-ca-3jO" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="KOe-u2-iJ6"/>
                 <constraint firstItem="xDO-zC-LfC" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="MWI-ms-Rv4"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="xDO-zC-LfC" secondAttribute="trailing" id="OHR-W8-dha"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="MWQ-ca-3jO" secondAttribute="trailing" id="Ut9-BG-3Le"/>
                 <constraint firstItem="xDO-zC-LfC" firstAttribute="top" secondItem="MWQ-ca-3jO" secondAttribute="bottom" id="Zxh-z9-aOC"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="1VQ-F1-JzX" secondAttribute="trailing" id="bAY-dK-Nm9"/>
                 <constraint firstItem="MWQ-ca-3jO" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="ePB-K7-6ZN"/>
                 <constraint firstItem="0ad-UX-0V5" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="rB6-u2-Lfl"/>
+                <constraint firstItem="1VQ-F1-JzX" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="x10-Sr-tYd"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="1VQ-F1-JzX" secondAttribute="trailing" id="yAV-CV-t2T"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <point key="canvasLocation" x="436.81640625" y="40.234375"/>
+            <point key="canvasLocation" x="436.81640625" y="61.328125"/>
         </view>
     </objects>
     <resources>
         <image name="바나나우유" width="163" height="190.66667175292969"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemPinkColor">
+            <color red="1" green="0.17647058823529413" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/VendingMachineApp/VendingMachineApp/View/BeverageView.xib
+++ b/VendingMachineApp/VendingMachineApp/View/BeverageView.xib
@@ -31,7 +31,7 @@
                     <rect key="frame" x="0.0" y="0.0" width="287" height="30"/>
                     <state key="normal" title="추가"/>
                     <connections>
-                        <action selector="didTapAddBeverageButton:" destination="-1" eventType="touchUpInside" id="H5n-ps-dAr"/>
+                        <action selector="addBeverage:" destination="-2" eventType="touchUpInside" id="As6-5R-i3m"/>
                     </connections>
                 </button>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0ad-UX-0V5">

--- a/VendingMachineApp/VendingMachineApp/View/BeverageView.xib
+++ b/VendingMachineApp/VendingMachineApp/View/BeverageView.xib
@@ -51,6 +51,9 @@
                     <state key="normal" title="구매">
                         <color key="titleColor" systemColor="systemPinkColor"/>
                     </state>
+                    <connections>
+                        <action selector="buyBeverage:" destination="-2" eventType="touchUpInside" id="rvp-zO-TrY"/>
+                    </connections>
                 </button>
             </subviews>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>

--- a/VendingMachineApp/VendingMachineApp/View/PurchasedItemListScrollView.swift
+++ b/VendingMachineApp/VendingMachineApp/View/PurchasedItemListScrollView.swift
@@ -1,0 +1,35 @@
+//
+//  PurchasedItemListScrollView.swift
+//  VendingMachineApp
+//
+//  Created by 오킹 on 2021/03/22.
+//
+
+import UIKit
+
+class PurchasedItemListScrollView: UIScrollView {
+    
+    private var xPosition: CGFloat
+        
+    override init(frame: CGRect) {
+        xPosition = 0
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        xPosition = 0
+        super.init(coder: coder)
+    }
+    
+    public func addImageView(image: UIImage) {
+        let width: CGFloat = 140
+        let height: CGFloat = 100
+        let imageView = UIImageView(image: image)
+        
+        imageView.frame = CGRect(x: xPosition, y: 0, width: width, height: height)
+        self.addSubview(imageView)
+        xPosition += imageView.frame.width
+        self.contentSize = CGSize(width: xPosition, height: imageView.frame.height)
+        
+    }
+}


### PR DESCRIPTION
## 작업 목록
- [x] 실행이후 구매 목록을 화면 아래 이미지로 추가한다.
- [x] 화면 아래 부분을 좌우로 스크롤 가능하도록 만들고 상품 이미지를 추가한다. 계속 추가해도 스크롤할 수 있어야 한다.
- [x] 특정 제품을 구매할 때마다 해당 제품 이미지를 추가하도록 구현한다.
  > NotificationCenter를 활용
- [x] 특정 시점에 `self.scrollView.addSubView()` 메서드로 UIImageView를 수동 추가한다.

## 학습 키워드
- Responder chain
- UIScrollView
- SceneDelegate에서 rootViewController 가져오기

## 고민과 해결
- (xib) View - ViewController 간 연결 : notification, addTarget 사용해봤는데
- First Reponder을 이용하는게 제일 깔끔한 것 같아서 사용했습니다.